### PR TITLE
Add CSRF tokens to authentication forms

### DIFF
--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -52,6 +52,7 @@
                     <div th:if="${userProfile.imageUrl == null}" class="user-badge" th:text="${userProfile.initials}">U</div>
                     <span class="fw-semibold" th:text="${userProfile.displayName}">Jane Doe</span>
                     <form th:action="@{/logout}" method="post">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                         <button type="submit" class="btn btn-outline-light btn-sm">Logout</button>
                     </form>
                 </div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -21,6 +21,7 @@
                         You have been signed out.
                     </div>
                     <form th:action="@{/login}" method="post" class="needs-validation" novalidate>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                         <div class="mb-3">
                             <label for="email" class="form-label">Email</label>
                             <input type="email" class="form-control" id="email" name="email" required autofocus>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -15,6 +15,7 @@
                         Registration is currently disabled. Configure Firestore credentials to enable sign ups.
                     </div>
                     <form th:action="@{/register}" th:object="${registrationForm}" method="post" class="needs-validation" novalidate>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                         <div th:if="${#fields.hasGlobalErrors()}" class="alert alert-danger" role="alert">
                             <p class="mb-0" th:each="error : ${#fields.globalErrors()}" th:text="${error}">An error occurred.</p>
                         </div>


### PR DESCRIPTION
## Summary
- include the Spring Security CSRF token in the global logout form so the POST request is accepted
- add the CSRF token field to the custom login and registration forms to keep form submissions working when CSRF is enabled

## Testing
- ./mvnw test *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d3d06e71ec8324b1f72511849321e6