### PR TITLE
Add receipts upload page with Google Cloud Storage integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ ResponsiveAuthApp is a Spring Boot starter application showcasing a responsive w
 - Responsive layout powered by Bootstrap 5, including a splash screen and persistent top navigation bar with user avatar/initials.
 - Sample Thymeleaf pages for unauthenticated and authenticated visitors.
 - Ready-to-style components and custom CSS for cohesive branding.
+- Optional receipts workspace with drag-and-drop uploads that sync to Google Cloud Storage.
 
 ## Getting started
 
@@ -22,14 +23,16 @@ ResponsiveAuthApp is a Spring Boot starter application showcasing a responsive w
    ```
 
 3. Configure Firestore if you want to enable user self-registration (see [Firestore configuration](#firestore-configuration)).
+4. (Optional) Configure Google Cloud Storage to enable the receipts upload page (see
+   [Google Cloud Storage configuration](#google-cloud-storage-configuration)).
 
-4. Build and run the application:
+5. Build and run the application:
 
    ```bash
    ./mvnw spring-boot:run
    ```
 
-5. Navigate to <http://localhost:8080> to explore the experience.
+6. Navigate to <http://localhost:8080> to explore the experience.
 
 ### Firestore configuration
 
@@ -66,6 +69,49 @@ Follow these steps to allow the application to persist users and profiles in Fir
 
 5. **Restart the application** so that the new configuration is picked up. Visit `/register` to create your first user and then sign in with the same email address on the `/login` page.
 
+### Google Cloud Storage configuration
+
+Enabling Google Cloud Storage (GCS) unlocks the `/receipts` workspace where authenticated users can drag, drop, and review receipt files.
+
+1. **Choose or create a Google Cloud project**
+   - Visit <https://console.cloud.google.com/projectcreate> to create a new project or switch to an existing one.
+   - Make note of the _Project ID_; you will reference it from your environment variables.
+
+2. **Enable the Cloud Storage API**
+   - In the Google Cloud Console, open **APIs & Services → Library**.
+   - Search for _"Cloud Storage API"_, select it, and click **Enable**.
+
+3. **Create a receipts bucket**
+   - Navigate to **Cloud Storage → Buckets** and click **Create**.
+   - Supply a globally unique bucket name (for example `responsive-auth-receipts`).
+   - Choose a region close to your users and keep **Uniform bucket-level access** enabled for simplified permissions.
+   - Leave the bucket private; the application will read the file list through service account credentials.
+
+4. **Create a dedicated service account**
+   - Go to **IAM & Admin → Service Accounts** and click **Create service account**.
+   - Provide a descriptive name such as `responsive-auth-receipts-uploader`.
+   - Grant the role **Storage Object Admin** (or a more restrictive custom role that allows `storage.objects.create`, `storage.objects.get`, and `storage.objects.list`).
+   - Skip granting user access and finish the wizard.
+
+5. **Generate a service account key**
+   - From the new service account's **Keys** tab click **Add key → Create new key** and choose **JSON**.
+   - Store the downloaded JSON file securely (for example `/home/user/secrets/gcs-receipts.json`). Never commit the file to source control.
+
+6. **Export the environment variables used by the application**
+
+   ```bash
+   export GCS_ENABLED=true
+   export GCS_BUCKET=responsive-auth-receipts           # Replace with your bucket name
+   export GCS_CREDENTIALS=file:/home/user/secrets/gcs-receipts.json
+   export GCS_PROJECT_ID=your-project-id                # Optional if derived from credentials
+   ```
+
+   - The `GCS_CREDENTIALS` variable accepts any Spring `Resource` URI. When running on Google Cloud (Compute Engine, Cloud Run, etc.) you can omit `GCS_CREDENTIALS` and rely on the platform's default service account; in that case the application will call `GoogleCredentials.getApplicationDefault()`.
+   - Keep credentials outside of the repository and inject them through your deployment platform's secret manager in production.
+
+7. **Restart the application** and sign in to an authenticated account.
+   - Open <http://localhost:8080/receipts> to upload files and view the bucket inventory table populated from Cloud Storage.
+
 ### Fallback credentials
 
 When Firestore integration is disabled the application falls back to an in-memory user store, but no accounts are created automatically. Configure explicit credentials for local testing by defining `firestore.fallback-users` entries in `application.yml` (or through environment variables):
@@ -94,7 +140,7 @@ To enable Google sign-in, create OAuth credentials in the Google Cloud Console a
 
 - `src/main/java` – Spring Boot application, configuration, and MVC controllers.
 - `src/main/resources/templates` – Thymeleaf templates using a reusable layout.
-- `src/main/resources/static` – Custom styling for avatars, splash screen, and layout refinements.
+- `src/main/resources/static` – Custom CSS and JavaScript for avatars, splash screen, and feature pages such as receipts.
 - `src/test/java` – Sample test bootstrapped by Spring Initializr.
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <properties>
                 <java.version>21</java.version>
                 <google-cloud-firestore.version>3.33.0</google-cloud-firestore.version>
+                <google-cloud-storage.version>2.40.1</google-cloud-storage.version>
         </properties>
         <dependencies>
                 <dependency>
@@ -59,6 +60,12 @@
                         <groupId>com.google.cloud</groupId>
                         <artifactId>google-cloud-firestore</artifactId>
                         <version>${google-cloud-firestore.version}</version>
+                </dependency>
+
+                <dependency>
+                        <groupId>com.google.cloud</groupId>
+                        <artifactId>google-cloud-storage</artifactId>
+                        <version>${google-cloud-storage.version}</version>
                 </dependency>
 
                 <dependency>

--- a/src/main/java/dev/pekelund/responsiveauth/storage/DisabledReceiptStorageService.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/DisabledReceiptStorageService.java
@@ -1,0 +1,28 @@
+package dev.pekelund.responsiveauth.storage;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@ConditionalOnMissingBean(ReceiptStorageService.class)
+public class DisabledReceiptStorageService implements ReceiptStorageService {
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+
+    @Override
+    public List<ReceiptFile> listReceipts() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void uploadFiles(List<MultipartFile> files) {
+        throw new ReceiptStorageException("Google Cloud Storage integration is disabled");
+    }
+}
+

--- a/src/main/java/dev/pekelund/responsiveauth/storage/DisabledReceiptStorageService.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/DisabledReceiptStorageService.java
@@ -3,11 +3,13 @@ package dev.pekelund.responsiveauth.storage;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @ConditionalOnMissingBean(ReceiptStorageService.class)
+@ConditionalOnProperty(value = "gcs.enabled", havingValue = "false", matchIfMissing = true)
 public class DisabledReceiptStorageService implements ReceiptStorageService {
 
     @Override

--- a/src/main/java/dev/pekelund/responsiveauth/storage/GcsConfig.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/GcsConfig.java
@@ -1,0 +1,56 @@
+package dev.pekelund.responsiveauth.storage;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
+import java.io.InputStream;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@EnableConfigurationProperties(GcsProperties.class)
+public class GcsConfig {
+
+    private final GcsProperties properties;
+    private final ResourceLoader resourceLoader;
+
+    public GcsConfig(GcsProperties properties, ResourceLoader resourceLoader) {
+        this.properties = properties;
+        this.resourceLoader = resourceLoader;
+    }
+
+    @Bean
+    @ConditionalOnProperty(value = "gcs.enabled", havingValue = "true")
+    @ConditionalOnMissingBean
+    public Storage storage() throws IOException {
+        StorageOptions.Builder optionsBuilder = StorageOptions.newBuilder();
+        GoogleCredentials credentials;
+
+        if (StringUtils.hasText(properties.getCredentials())) {
+            Resource resource = resourceLoader.getResource(properties.getCredentials());
+            Assert.isTrue(resource.exists(),
+                () -> "Google Cloud credentials resource not found at " + properties.getCredentials());
+            try (InputStream inputStream = resource.getInputStream()) {
+                credentials = GoogleCredentials.fromStream(inputStream);
+            }
+        } else {
+            credentials = GoogleCredentials.getApplicationDefault();
+        }
+
+        optionsBuilder.setCredentials(credentials);
+        if (StringUtils.hasText(properties.getProjectId())) {
+            optionsBuilder.setProjectId(properties.getProjectId());
+        }
+
+        return optionsBuilder.build().getService();
+    }
+}
+

--- a/src/main/java/dev/pekelund/responsiveauth/storage/GcsProperties.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/GcsProperties.java
@@ -1,0 +1,61 @@
+package dev.pekelund.responsiveauth.storage;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "gcs")
+public class GcsProperties {
+
+    /**
+     * Flag indicating whether Google Cloud Storage integration is enabled.
+     */
+    private boolean enabled;
+
+    /**
+     * Optional path or resource string that resolves to the service account credentials file.
+     * When omitted, application default credentials will be used.
+     */
+    private String credentials;
+
+    /**
+     * Optional Google Cloud project identifier used when building the storage client.
+     */
+    private String projectId;
+
+    /**
+     * Name of the Google Cloud Storage bucket that stores receipt uploads.
+     */
+    private String bucket;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getCredentials() {
+        return credentials;
+    }
+
+    public void setCredentials(String credentials) {
+        this.credentials = credentials;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+}
+

--- a/src/main/java/dev/pekelund/responsiveauth/storage/GcsReceiptStorageService.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/GcsReceiptStorageService.java
@@ -1,0 +1,118 @@
+package dev.pekelund.responsiveauth.storage;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@ConditionalOnBean(Storage.class)
+public class GcsReceiptStorageService implements ReceiptStorageService {
+
+    private static final Pattern UNSAFE_FILENAME = Pattern.compile("[^A-Za-z0-9._-]");
+    private static final DateTimeFormatter OBJECT_PREFIX =
+        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss-SSS", Locale.US).withZone(ZoneOffset.UTC);
+
+    private final Storage storage;
+    private final GcsProperties properties;
+
+    public GcsReceiptStorageService(Storage storage, GcsProperties properties) {
+        this.storage = storage;
+        this.properties = properties;
+        Assert.isTrue(StringUtils.hasText(properties.getBucket()),
+            "gcs.bucket must be configured when Google Cloud Storage is enabled");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public List<ReceiptFile> listReceipts() {
+        try {
+            Iterable<Blob> blobs = storage.list(properties.getBucket()).iterateAll();
+            List<ReceiptFile> files = new ArrayList<>();
+            for (Blob blob : blobs) {
+                if (blob.isDirectory()) {
+                    continue;
+                }
+                files.add(new ReceiptFile(blob.getName(), blob.getSize(),
+                    blob.getUpdateTime() != null ? Instant.ofEpochMilli(blob.getUpdateTime()) : null,
+                    blob.getContentType()));
+            }
+            files.sort((left, right) -> {
+                Instant leftUpdated = left.updated();
+                Instant rightUpdated = right.updated();
+                if (leftUpdated == null && rightUpdated == null) {
+                    return left.name().compareToIgnoreCase(right.name());
+                }
+                if (leftUpdated == null) {
+                    return 1;
+                }
+                if (rightUpdated == null) {
+                    return -1;
+                }
+                return rightUpdated.compareTo(leftUpdated);
+            });
+            return files;
+        } catch (StorageException ex) {
+            throw new ReceiptStorageException("Unable to list receipt files", ex);
+        }
+    }
+
+    @Override
+    public void uploadFiles(List<MultipartFile> files) {
+        for (MultipartFile file : files) {
+            if (file == null || file.isEmpty()) {
+                continue;
+            }
+
+            String originalFilename = file.getOriginalFilename();
+            String objectName = buildObjectName(originalFilename);
+            BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(properties.getBucket(), objectName))
+                .setContentType(file.getContentType())
+                .build();
+
+            try (InputStream inputStream = file.getInputStream()) {
+                storage.createFrom(blobInfo, inputStream);
+            } catch (IOException | StorageException ex) {
+                String displayName = StringUtils.hasText(originalFilename) ? originalFilename : objectName;
+                throw new ReceiptStorageException("Failed to upload file '%s'".formatted(displayName), ex);
+            }
+        }
+    }
+
+    private String buildObjectName(String originalFilename) {
+        String filename = StringUtils.hasText(originalFilename) ? originalFilename : "receipt";
+        filename = filename.replace('\\', '/');
+        int slashIndex = filename.lastIndexOf('/');
+        if (slashIndex >= 0 && slashIndex < filename.length() - 1) {
+            filename = filename.substring(slashIndex + 1);
+        }
+        filename = UNSAFE_FILENAME.matcher(filename).replaceAll("_");
+        if (!StringUtils.hasText(filename)) {
+            filename = "receipt";
+        }
+        String prefix = OBJECT_PREFIX.format(Instant.now());
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        return prefix + "_" + suffix + "_" + filename;
+    }
+}
+

--- a/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptFile.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptFile.java
@@ -1,0 +1,22 @@
+package dev.pekelund.responsiveauth.storage;
+
+import java.time.Instant;
+
+public record ReceiptFile(String name, long size, Instant updated, String contentType) {
+
+    public String formattedSize() {
+        if (size <= 0) {
+            return "0 B";
+        }
+
+        String[] units = {"B", "KB", "MB", "GB", "TB"};
+        double readableSize = size;
+        int unitIndex = 0;
+        while (readableSize >= 1024 && unitIndex < units.length - 1) {
+            readableSize /= 1024;
+            unitIndex++;
+        }
+        return String.format("%.1f %s", readableSize, units[unitIndex]);
+    }
+}
+

--- a/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptStorageException.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptStorageException.java
@@ -1,0 +1,13 @@
+package dev.pekelund.responsiveauth.storage;
+
+public class ReceiptStorageException extends RuntimeException {
+
+    public ReceiptStorageException(String message) {
+        super(message);
+    }
+
+    public ReceiptStorageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptStorageService.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptStorageService.java
@@ -1,0 +1,14 @@
+package dev.pekelund.responsiveauth.storage;
+
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ReceiptStorageService {
+
+    boolean isEnabled();
+
+    List<ReceiptFile> listReceipts();
+
+    void uploadFiles(List<MultipartFile> files);
+}
+

--- a/src/main/java/dev/pekelund/responsiveauth/web/ReceiptController.java
+++ b/src/main/java/dev/pekelund/responsiveauth/web/ReceiptController.java
@@ -1,0 +1,88 @@
+package dev.pekelund.responsiveauth.web;
+
+import dev.pekelund.responsiveauth.storage.ReceiptFile;
+import dev.pekelund.responsiveauth.storage.ReceiptStorageException;
+import dev.pekelund.responsiveauth.storage.ReceiptStorageService;
+import java.util.Collections;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.multipart.MultipartFile;
+
+@Controller
+public class ReceiptController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReceiptController.class);
+
+    private final ReceiptStorageService receiptStorageService;
+
+    public ReceiptController(ReceiptStorageService receiptStorageService) {
+        this.receiptStorageService = receiptStorageService;
+    }
+
+    @GetMapping("/receipts")
+    public String receipts(Model model) {
+        model.addAttribute("pageTitle", "Receipts");
+        model.addAttribute("storageEnabled", receiptStorageService.isEnabled());
+
+        List<ReceiptFile> receiptFiles = Collections.emptyList();
+        String listingError = null;
+
+        if (receiptStorageService.isEnabled()) {
+            try {
+                receiptFiles = receiptStorageService.listReceipts();
+            } catch (ReceiptStorageException ex) {
+                listingError = ex.getMessage();
+                LOGGER.warn("Failed to list receipt files", ex);
+            }
+        }
+
+        model.addAttribute("files", receiptFiles);
+        model.addAttribute("listingError", listingError);
+        return "receipts";
+    }
+
+    @PostMapping("/receipts/upload")
+    public String uploadReceipts(
+        @RequestParam(value = "files", required = false) List<MultipartFile> files,
+        RedirectAttributes redirectAttributes
+    ) {
+        if (!receiptStorageService.isEnabled()) {
+            redirectAttributes.addFlashAttribute("errorMessage",
+                "Receipt uploads are disabled. Configure Google Cloud Storage to enable this feature.");
+            return "redirect:/receipts";
+        }
+
+        List<MultipartFile> sanitizedFiles = files == null ? List.of()
+            : files.stream().filter(file -> file != null && !file.isEmpty()).toList();
+
+        if (sanitizedFiles.isEmpty()) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Please choose at least one file to upload.");
+            return "redirect:/receipts";
+        }
+
+        if (sanitizedFiles.size() > 10) {
+            redirectAttributes.addFlashAttribute("errorMessage", "You can upload up to 10 files at a time.");
+            return "redirect:/receipts";
+        }
+
+        try {
+            receiptStorageService.uploadFiles(sanitizedFiles);
+            int count = sanitizedFiles.size();
+            redirectAttributes.addFlashAttribute("successMessage",
+                "%d file%s uploaded successfully.".formatted(count, count == 1 ? "" : "s"));
+        } catch (ReceiptStorageException ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+            LOGGER.error("Failed to upload receipts", ex);
+        }
+
+        return "redirect:/receipts";
+    }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,3 +25,8 @@ firestore:
   project-id: ${FIRESTORE_PROJECT_ID:}
   users-collection: ${FIRESTORE_USERS_COLLECTION:users}
   default-role: ${FIRESTORE_DEFAULT_ROLE:ROLE_USER}
+gcs:
+  enabled: ${GCS_ENABLED:false}
+  credentials: ${GCS_CREDENTIALS:}
+  project-id: ${GCS_PROJECT_ID:}
+  bucket: ${GCS_BUCKET:}

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -64,6 +64,37 @@ footer {
     background-color: #f1f5f9;
 }
 
+.upload-dropzone {
+    border: 2px dashed rgba(13, 110, 253, 0.35);
+    border-radius: 1rem;
+    background-color: rgba(13, 110, 253, 0.05);
+    transition: all 0.2s ease-in-out;
+    cursor: pointer;
+}
+
+.upload-dropzone.is-dragover {
+    border-style: solid;
+    background-color: rgba(13, 110, 253, 0.12);
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.15);
+}
+
+.dropzone-icon {
+    font-size: 2.75rem;
+}
+
+.receipt-upload .list-group-item {
+    border-left: 0;
+    border-right: 0;
+}
+
+.receipt-upload .list-group-item:first-child {
+    border-top: 0;
+}
+
+.receipt-upload .list-group-item:last-child {
+    border-bottom: 0;
+}
+
 @media (max-width: 767.98px) {
     .user-avatar,
     .user-badge {

--- a/src/main/resources/static/js/receipts.js
+++ b/src/main/resources/static/js/receipts.js
@@ -1,0 +1,121 @@
+(function () {
+    const dropzone = document.getElementById('receipt-dropzone');
+    const fileInput = document.getElementById('receipt-files');
+    const triggerButton = document.getElementById('trigger-file-select');
+    const selectedList = document.getElementById('selected-files');
+    const uploadButton = document.getElementById('upload-button');
+    const hint = document.getElementById('file-limit-hint');
+
+    if (!dropzone || !fileInput || !selectedList || !uploadButton) {
+        return;
+    }
+
+    const MAX_FILES = 10;
+
+    function formatBytes(bytes) {
+        if (!bytes || bytes <= 0) {
+            return '0 B';
+        }
+        const units = ['B', 'KB', 'MB', 'GB'];
+        let size = bytes;
+        let unit = 0;
+        while (size >= 1024 && unit < units.length - 1) {
+            size /= 1024;
+            unit += 1;
+        }
+        return `${size.toFixed(1)} ${units[unit]}`;
+    }
+
+    function rebuildFileList(files) {
+        const dataTransfer = new DataTransfer();
+        files.forEach((file) => dataTransfer.items.add(file));
+        fileInput.files = dataTransfer.files;
+    }
+
+    function refreshSelectedFiles() {
+        const files = Array.from(fileInput.files);
+        selectedList.innerHTML = '';
+
+        if (files.length === 0) {
+            uploadButton.disabled = true;
+            if (hint) {
+                hint.textContent = `You can add up to ${MAX_FILES} files per upload.`;
+            }
+            return;
+        }
+
+        files.forEach((file, index) => {
+            const item = document.createElement('li');
+            item.className = 'list-group-item d-flex justify-content-between align-items-center';
+
+            const details = document.createElement('div');
+            details.className = 'text-start';
+            details.innerHTML = `<strong>${file.name}</strong><br><span class="text-muted small">${formatBytes(file.size)}</span>`;
+
+            const removeButton = document.createElement('button');
+            removeButton.type = 'button';
+            removeButton.className = 'btn btn-link text-danger p-0 small';
+            removeButton.textContent = 'Remove';
+            removeButton.addEventListener('click', () => {
+                files.splice(index, 1);
+                rebuildFileList(files);
+                refreshSelectedFiles();
+            });
+
+            item.append(details, removeButton);
+            selectedList.appendChild(item);
+        });
+
+        uploadButton.disabled = false;
+        if (hint) {
+            hint.textContent = `${files.length} file${files.length === 1 ? '' : 's'} ready for upload.`;
+        }
+    }
+
+    function handleFiles(newFiles) {
+        if (!newFiles || newFiles.length === 0) {
+            return;
+        }
+
+        const currentFiles = Array.from(fileInput.files);
+        const merged = currentFiles.concat(Array.from(newFiles));
+
+        if (merged.length > MAX_FILES) {
+            merged.splice(MAX_FILES);
+            if (hint) {
+                hint.textContent = `Only the first ${MAX_FILES} files were added.`;
+            }
+        }
+
+        rebuildFileList(merged);
+        refreshSelectedFiles();
+    }
+
+    triggerButton?.addEventListener('click', () => fileInput.click());
+
+    fileInput.addEventListener('change', (event) => {
+        handleFiles(event.target.files);
+        fileInput.value = '';
+    });
+
+    ['dragenter', 'dragover'].forEach((type) => {
+        dropzone.addEventListener(type, (event) => {
+            event.preventDefault();
+            dropzone.classList.add('is-dragover');
+        });
+    });
+
+    ['dragleave', 'drop'].forEach((type) => {
+        dropzone.addEventListener(type, (event) => {
+            event.preventDefault();
+            dropzone.classList.remove('is-dragover');
+        });
+    });
+
+    dropzone.addEventListener('drop', (event) => {
+        if (event.dataTransfer?.files) {
+            handleFiles(event.dataTransfer.files);
+        }
+    });
+})();
+

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -9,6 +9,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
+          integrity="sha384-2+92fIk9A94svjuvVJ8H7kSNXpV+KuQlGn9UdtlBDO9Rt1f/IhAvc2V9zX7JF9T6" crossorigin="anonymous">
     <link th:href="@{/css/styles.css}" rel="stylesheet">
 </head>
 <body class="d-flex flex-column min-vh-100">
@@ -43,6 +45,11 @@
                     <a class="nav-link"
                        th:classappend="${currentUri == '/dashboard'} ? ' active'"
                        th:href="@{/dashboard}">Dashboard</a>
+                </li>
+                <li class="nav-item" th:if="${userProfile.authenticated}">
+                    <a class="nav-link"
+                       th:classappend="${#strings.startsWith(currentUri, '/receipts')} ? ' active'"
+                       th:href="@{/receipts}">Receipts</a>
                 </li>
             </ul>
             <div class="d-flex align-items-center gap-3 ms-lg-auto">

--- a/src/main/resources/templates/receipts.html
+++ b/src/main/resources/templates/receipts.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout(${pageTitle}, ~{::section})}">
+<head>
+    <title th:text="${pageTitle}">Receipts</title>
+</head>
+<body>
+<section class="py-3 py-lg-4">
+    <div class="row g-4">
+        <div class="col-lg-7">
+            <div class="card shadow-sm border-0 h-100">
+                <div class="card-body p-4">
+                    <h1 class="h3 fw-semibold text-primary mb-3">Upload receipts</h1>
+                    <p class="text-muted mb-4">Drop PDF or image receipts into the area below, or click to choose files
+                        from your computer. Up to 10 files can be uploaded at a time.</p>
+
+                    <div th:if="${successMessage}" class="alert alert-success" role="alert">
+                        <span th:text="${successMessage}">Files uploaded successfully.</span>
+                    </div>
+                    <div th:if="${errorMessage}" class="alert alert-danger" role="alert">
+                        <span th:text="${errorMessage}">Upload failed.</span>
+                    </div>
+
+                    <div th:if="${!storageEnabled}" class="alert alert-warning" role="alert">
+                        Receipt uploads are currently disabled. Follow the Google Cloud Storage setup instructions in the
+                        README to enable this feature.
+                    </div>
+
+                    <form th:if="${storageEnabled}" th:action="@{/receipts/upload}" method="post"
+                          enctype="multipart/form-data" class="receipt-upload">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <div id="receipt-dropzone" class="upload-dropzone text-center p-4">
+                            <input id="receipt-files" class="visually-hidden" type="file" name="files" multiple>
+                            <div class="dropzone-icon text-primary mb-2">
+                                <i class="bi bi-cloud-arrow-up-fill"></i>
+                            </div>
+                            <p class="fw-semibold mb-1">Drag &amp; drop receipts here</p>
+                            <p class="text-muted small mb-3">or</p>
+                            <button type="button" class="btn btn-outline-primary" id="trigger-file-select">Click to
+                                select files
+                            </button>
+                            <p class="text-muted small mt-3 mb-0" id="file-limit-hint">You can add up to 10 files per
+                                upload.</p>
+                        </div>
+
+                        <ul class="list-group list-group-flush mt-3" id="selected-files" aria-live="polite"></ul>
+
+                        <div class="d-flex justify-content-end mt-3">
+                            <button type="submit" class="btn btn-primary" id="upload-button" disabled>Upload
+                                receipt files
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-5">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body p-4">
+                    <h2 class="h5 fw-semibold mb-3">Quick start checklist</h2>
+                    <ol class="list-group list-group-numbered list-group-flush">
+                        <li class="list-group-item">Create or select a Google Cloud project.</li>
+                        <li class="list-group-item">Enable the Cloud Storage API and create a bucket for receipts.</li>
+                        <li class="list-group-item">Generate a service account key with Storage Admin access.</li>
+                        <li class="list-group-item">Set the <code>GCS_*</code> environment variables before starting the
+                            app.
+                        </li>
+                    </ol>
+                    <p class="text-muted small mt-3 mb-0">See the repository README for detailed setup instructions and
+                        recommended security practices.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body p-4">
+            <div class="d-flex align-items-center justify-content-between mb-3">
+                <h2 class="h5 fw-semibold mb-0">Stored receipts</h2>
+                <span class="badge bg-primary-subtle text-primary" th:if="${files}" th:text="${files.size()} + ' files'">0 files</span>
+            </div>
+
+            <div th:if="${listingError}" class="alert alert-danger" role="alert">
+                <span th:text="${listingError}">Unable to list files.</span>
+            </div>
+
+            <div th:if="${files == null or #lists.isEmpty(files)}" class="text-center text-muted py-5">
+                <p class="mb-0">No receipts have been uploaded yet.</p>
+            </div>
+
+            <div th:if="${files != null and !#lists.isEmpty(files)}" class="table-responsive">
+                <table class="table align-middle">
+                    <thead class="table-light">
+                    <tr>
+                        <th scope="col">File name</th>
+                        <th scope="col" class="text-end">Size</th>
+                        <th scope="col">Last updated</th>
+                        <th scope="col">Content type</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="file : ${files}">
+                        <td>
+                            <span class="fw-semibold" th:text="${file.name()}">receipt.pdf</span>
+                        </td>
+                        <td class="text-end" th:text="${file.formattedSize()}">24.5 KB</td>
+                        <td th:text="${file.updated() != null ? #temporals.format(file.updated(), 'yyyy-MM-dd HH:mm:ss') : '—'}">2024-01-01 10:30:00</td>
+                        <td th:text="${file.contentType() != null ? file.contentType() : '—'}">application/pdf</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</section>
+
+<script defer th:src="@{/js/receipts.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add configuration properties and services for connecting to Google Cloud Storage when enabled
- create a receipts workspace with drag-and-drop uploads, table listings, and a navigation entry for signed-in users
- document the GCS setup process and wire the new storage dependency and application properties

## Testing
- ./mvnw test *(fails: unable to resolve Spring Boot parent POM because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d3d87f16dc83249d9ac8f0ccce01d1