### PR TITLE
Improve compatibility of receipts upload button

### DIFF
--- a/src/main/resources/static/js/receipts.js
+++ b/src/main/resources/static/js/receipts.js
@@ -5,7 +5,7 @@
     const selectedList = document.getElementById('selected-files');
     const uploadButton = document.getElementById('upload-button');
     const hint = document.getElementById('file-limit-hint');
-    const form = dropzone?.closest('form');
+    const form = dropzone ? dropzone.closest('form') : null;
 
     if (!dropzone || !fileInput || !selectedList || !uploadButton) {
         return;
@@ -128,7 +128,9 @@
         refreshSelectedFiles();
     }
 
-    triggerButton?.addEventListener('click', () => fileInput.click());
+    if (triggerButton) {
+        triggerButton.addEventListener('click', () => fileInput.click());
+    }
 
     fileInput.addEventListener('change', (event) => {
         handleFiles(event.target.files);
@@ -150,7 +152,7 @@
     });
 
     dropzone.addEventListener('drop', (event) => {
-        if (event.dataTransfer?.files) {
+        if (event.dataTransfer && event.dataTransfer.files) {
             handleFiles(event.dataTransfer.files);
         }
     });


### PR DESCRIPTION
## Summary
- replace optional chaining in the receipts upload script to keep it compatible with browsers that lack that syntax
- keep the drop handler defensive so file selection keeps working when dataTransfer is unavailable

## Testing
- ./mvnw -q test *(fails: network is unreachable while resolving Spring Boot parent from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_b_68d3ef972514832491e3b1c02a4e10be