### PR TITLE
Fix receipt upload button clearing files

### DIFF
--- a/src/main/resources/static/js/receipts.js
+++ b/src/main/resources/static/js/receipts.js
@@ -134,7 +134,10 @@
 
     fileInput.addEventListener('change', (event) => {
         handleFiles(event.target.files);
-        event.target.value = '';
+
+        if (!supportsFileAssignment) {
+            event.target.value = '';
+        }
     });
 
     ['dragenter', 'dragover'].forEach((type) => {


### PR DESCRIPTION
## Summary
- stop clearing the underlying file input whenever the browser supports programmatically assigning FileList values
- retain the previous reset behaviour only for browsers that require the manual FormData fallback

## Testing
- `mvn -q test` *(fails: repository cannot reach Maven Central in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d43ede3bac83249f631c48d136e157