### PR TITLE
Track receipt owner for uploaded receipts

### DIFF
--- a/src/main/java/dev/pekelund/responsiveauth/storage/DisabledReceiptStorageService.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/DisabledReceiptStorageService.java
@@ -23,7 +23,7 @@ public class DisabledReceiptStorageService implements ReceiptStorageService {
     }
 
     @Override
-    public void uploadFiles(List<MultipartFile> files) {
+    public void uploadFiles(List<MultipartFile> files, ReceiptOwner owner) {
         throw new ReceiptStorageException("Google Cloud Storage integration is disabled");
     }
 }

--- a/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptFile.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptFile.java
@@ -2,7 +2,7 @@ package dev.pekelund.responsiveauth.storage;
 
 import java.time.Instant;
 
-public record ReceiptFile(String name, long size, Instant updated, String contentType) {
+public record ReceiptFile(String name, long size, Instant updated, String contentType, ReceiptOwner owner) {
 
     public String formattedSize() {
         if (size <= 0) {
@@ -17,6 +17,30 @@ public record ReceiptFile(String name, long size, Instant updated, String conten
             unitIndex++;
         }
         return String.format("%.1f %s", readableSize, units[unitIndex]);
+    }
+
+    public String ownerDisplayName() {
+        if (owner == null) {
+            return "—";
+        }
+
+        if (hasText(owner.displayName())) {
+            return owner.displayName();
+        }
+
+        if (hasText(owner.email())) {
+            return owner.email();
+        }
+
+        if (hasText(owner.id())) {
+            return owner.id();
+        }
+
+        return "—";
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 }
 

--- a/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptOwner.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptOwner.java
@@ -1,0 +1,56 @@
+package dev.pekelund.responsiveauth.storage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public record ReceiptOwner(String id, String displayName, String email) {
+
+    public static final String METADATA_OWNER_ID = "receipt.owner.id";
+    public static final String METADATA_OWNER_DISPLAY_NAME = "receipt.owner.displayName";
+    public static final String METADATA_OWNER_EMAIL = "receipt.owner.email";
+
+    public ReceiptOwner {
+        id = normalize(id);
+        displayName = normalize(displayName);
+        email = normalize(email);
+    }
+
+    public boolean hasValues() {
+        return id != null || displayName != null || email != null;
+    }
+
+    public Map<String, String> toMetadata() {
+        Map<String, String> metadata = new HashMap<>();
+        if (id != null) {
+            metadata.put(METADATA_OWNER_ID, id);
+        }
+        if (displayName != null) {
+            metadata.put(METADATA_OWNER_DISPLAY_NAME, displayName);
+        }
+        if (email != null) {
+            metadata.put(METADATA_OWNER_EMAIL, email);
+        }
+        return metadata;
+    }
+
+    public static ReceiptOwner fromMetadata(Map<String, String> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return null;
+        }
+
+        ReceiptOwner owner = new ReceiptOwner(
+            metadata.get(METADATA_OWNER_ID),
+            metadata.get(METADATA_OWNER_DISPLAY_NAME),
+            metadata.get(METADATA_OWNER_EMAIL));
+        return owner.hasValues() ? owner : null;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}
+

--- a/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptStorageService.java
+++ b/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptStorageService.java
@@ -9,6 +9,6 @@ public interface ReceiptStorageService {
 
     List<ReceiptFile> listReceipts();
 
-    void uploadFiles(List<MultipartFile> files);
+    void uploadFiles(List<MultipartFile> files, ReceiptOwner owner);
 }
 

--- a/src/main/resources/templates/receipts.html
+++ b/src/main/resources/templates/receipts.html
@@ -99,6 +99,7 @@
                     <tr>
                         <th scope="col">File name</th>
                         <th scope="col" class="text-end">Size</th>
+                        <th scope="col">Uploaded by</th>
                         <th scope="col">Last updated</th>
                         <th scope="col">Content type</th>
                     </tr>
@@ -109,6 +110,7 @@
                             <span class="fw-semibold" th:text="${file.name()}">receipt.pdf</span>
                         </td>
                         <td class="text-end" th:text="${file.formattedSize()}">24.5 KB</td>
+                        <td th:text="${file.ownerDisplayName()}">—</td>
                         <td th:text="${file.updated() != null ? #temporals.format(file.updated(), 'yyyy-MM-dd HH:mm:ss') : '—'}">2024-01-01 10:30:00</td>
                         <td th:text="${file.contentType() != null ? file.contentType() : '—'}">application/pdf</td>
                     </tr>


### PR DESCRIPTION
## Summary
- capture the authenticated user when uploading receipt files and pass that context into storage operations
- persist owner metadata alongside each stored blob and surface it when listing stored receipts
- update the receipts table to show who uploaded each file

## Testing
- `./mvnw test` *(fails: unable to download Maven parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68d44547774883248f9fcc69a2323f4f