### PR TITLE
Add default service account to deploy script

### DIFF
--- a/deploy-cloud-function.sh
+++ b/deploy-cloud-function.sh
@@ -14,6 +14,8 @@ source setup-env.sh
 # Check if we're in the correct project
 CURRENT_PROJECT=$(gcloud config get-value project)
 EXPECTED_PROJECT="codex-test-473008"
+FUNCTION_SA=${FUNCTION_SA:-"receipt-parser@${EXPECTED_PROJECT}.iam.gserviceaccount.com"}
+echo "👤 Using service account: $FUNCTION_SA"
 
 if [ "$CURRENT_PROJECT" != "$EXPECTED_PROJECT" ]; then
     echo "⚠️  Switching to project: $EXPECTED_PROJECT"


### PR DESCRIPTION
## Summary
- default the FUNCTION_SA to the expected receipt parser account based on the project id
- log which service account email will be used during deployment for easier debugging

## Testing
- bash deploy-cloud-function.sh *(fails: setup-env.sh missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dd66789bec832499d2d1d18a2c090c