### PR TITLE
Fix Maven dependency resolution for Cloud Function builds

### DIFF
--- a/function/pom.xml
+++ b/function/pom.xml
@@ -94,6 +94,7 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/dependency</outputDirectory>
                             <includeScope>runtime</includeScope>
+                            <includeReactor>true</includeReactor>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary
- ensure the Cloud Function module's dependency copy step can resolve reactor modules during Cloud Build

## Testing
- ./mvnw -q -pl function -am -DskipTests clean package

------
https://chatgpt.com/codex/tasks/task_b_68de1daf066c8324befcba485d935709