### PR TITLE
Restrict default reactor modules for Cloud Function builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ ResponsiveAuthApp is a Spring Boot starter application showcasing a responsive w
 ### Quick Setup with Environment Script
 
 For the fastest setup, use the provided environment script that configures all necessary Google Cloud settings and then run the
-web module directly:
+web module directly. Activate the `include-web` Maven profile whenever you build or run the web module so that it participates in
+the multi-module reactor:
 
 ```bash
 # Source the environment setup script
 source setup-env.sh
 
 # Start the application
-./mvnw -pl web -am spring-boot:run
+./mvnw -Pinclude-web -pl web -am spring-boot:run
 ```
 
 The `setup-env.sh` script automatically configures:
@@ -48,10 +49,10 @@ The `setup-env.sh` script automatically configures:
 4. (Optional) Configure Google Cloud Storage to enable the receipts upload page (see
    [Google Cloud Storage configuration](#google-cloud-storage-configuration)).
 
-5. Build and run the web application module:
+5. Build and run the web application module (remember to enable the `include-web` profile):
 
    ```bash
-   ./mvnw -pl web -am spring-boot:run
+./mvnw -Pinclude-web -pl web -am spring-boot:run
    ```
 
 6. Navigate to <http://localhost:8080> to explore the experience.

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,17 @@
 
     <modules>
         <module>core</module>
-        <module>web</module>
         <module>function</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>include-web</id>
+            <modules>
+                <module>web</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <properties>
         <java.version>21</java.version>


### PR DESCRIPTION
## Summary
- limit the default Maven reactor to the core and function modules and gate the web module behind a new `include-web` profile
- document the new `include-web` profile so local web builds still work as expected

## Testing
- ./mvnw -pl function -am clean package -DskipTests

------
https://chatgpt.com/codex/tasks/task_b_68de27ffcf188324935ce33c4ea37032