### PR TITLE
Inline core sources during function build

### DIFF
--- a/function/pom.xml
+++ b/function/pom.xml
@@ -16,10 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>dev.pekelund</groupId>
-            <artifactId>responsive-auth-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
@@ -81,6 +77,40 @@
                     <execution>
                         <id>repackage</id>
                         <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>add-core-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/../core/src/main/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-core-resources</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/../core/src/main/resources</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Summary
- remove the direct dependency on the responsive-auth-core artifact from the Cloud Function module
- add build-helper configuration so the function module compiles directly against the shared core sources and resources

## Testing
- ./mvnw -pl function -am -DskipTests clean package

------
https://chatgpt.com/codex/tasks/task_b_68de2f7e622c83249bdee961ffe1a914