### PR TITLE
Ensure function build produces root-level jar

### DIFF
--- a/function/pom.xml
+++ b/function/pom.xml
@@ -69,6 +69,8 @@
     </properties>
 
     <build>
+        <finalName>${project.parent.artifactId}-${project.version}</finalName>
+        <directory>${project.basedir}/../target</directory>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Summary
- configure the function module to write its build output to the repository-level `target` directory
- align the packaged jar name with the parent artifact so Cloud Functions can locate `target/responsive-auth-0.0.1-SNAPSHOT.jar`

## Testing
- `./mvnw -pl function -am clean package -DskipTests`


------
https://chatgpt.com/codex/tasks/task_b_68de33898b448324b061ffe4f47e7572