### PR TITLE
Add manifest Start-Class for function jar

### DIFF
--- a/function/pom.xml
+++ b/function/pom.xml
@@ -83,6 +83,16 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Start-Class>dev.pekelund.responsiveauth.function.FunctionApplication</Start-Class>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.6.1</version>


### PR DESCRIPTION
## Summary
- ensure the function jar declares the Spring Boot start class in its manifest so Cloud Functions can locate it

## Testing
- ./mvnw -pl function package -DskipTests

------
https://chatgpt.com/codex/tasks/task_b_68de3ad8aaf483248004606de60fb7af