### PR TITLE
Fix receipt processing function to consume raw payload

### DIFF
--- a/function/src/main/java/dev/pekelund/responsiveauth/function/FunctionConfiguration.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/FunctionConfiguration.java
@@ -6,7 +6,6 @@ import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.vertexai.VertexAI;
-import io.cloudevents.CloudEvent;
 import io.micrometer.observation.ObservationRegistry;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -126,7 +125,7 @@ public class FunctionConfiguration {
     }
 
     @Bean("receiptProcessingFunction")
-    public Consumer<CloudEvent> receiptProcessingFunction(ObjectMapper objectMapper, ReceiptParsingHandler handler) {
+    public Consumer<String> receiptProcessingFunction(ObjectMapper objectMapper, ReceiptParsingHandler handler) {
         ReceiptProcessingFunction function = new ReceiptProcessingFunction(objectMapper, handler);
         LOGGER.info("Exposing receiptProcessingFunction bean backed by ReceiptProcessingFunction instance id {}",
             System.identityHashCode(function));

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/ReceiptProcessingFunction.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/ReceiptProcessingFunction.java
@@ -1,7 +1,6 @@
 package dev.pekelund.responsiveauth.function;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.cloudevents.CloudEvent;
 import java.io.IOException;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -10,7 +9,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Cloud Function entry point for receipt parsing.
  */
-public class ReceiptProcessingFunction implements Consumer<CloudEvent> {
+public class ReceiptProcessingFunction implements Consumer<String> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReceiptProcessingFunction.class);
 
@@ -25,19 +24,12 @@ public class ReceiptProcessingFunction implements Consumer<CloudEvent> {
     }
 
     @Override
-    public void accept(CloudEvent cloudEvent) {
-        LOGGER.info("ReceiptProcessingFunction.accept invoked with CloudEvent id {}", cloudEvent != null ? cloudEvent.getId() : null);
-        if (cloudEvent == null) {
-            LOGGER.warn("Received null CloudEvent");
+    public void accept(String payload) {
+        LOGGER.info("ReceiptProcessingFunction.accept invoked with payload length {}", payload != null ? payload.length() : null);
+        if (payload == null || payload.isBlank()) {
+            LOGGER.warn("Received null or empty payload");
             return;
         }
-        LOGGER.info("ReceiptProcessingFunction triggered - id: {}, type: {}, subject: {}, source: {}",
-            cloudEvent.getId(), cloudEvent.getType(), cloudEvent.getSubject(), cloudEvent.getSource());
-        if (cloudEvent.getData() == null) {
-            LOGGER.warn("CloudEvent did not contain any data");
-            return;
-        }
-        byte[] payload = cloudEvent.getData().toBytes();
         StorageObjectEvent storageObjectEvent = parseStorageObject(payload);
         LOGGER.info("ReceiptProcessingFunction delegating to handler {} for bucket {} object {}",
             System.identityHashCode(handler), storageObjectEvent != null ? storageObjectEvent.getBucket() : null,
@@ -45,7 +37,7 @@ public class ReceiptProcessingFunction implements Consumer<CloudEvent> {
         handler.handle(storageObjectEvent);
     }
 
-    private StorageObjectEvent parseStorageObject(byte[] payload) {
+    private StorageObjectEvent parseStorageObject(String payload) {
         try {
             return objectMapper.readValue(payload, StorageObjectEvent.class);
         } catch (IOException ex) {


### PR DESCRIPTION
## Summary
- change `ReceiptProcessingFunction` to consume the raw string payload and validate it before handing off to the handler
- update the Spring bean configuration to expose the function as a `Consumer<String>` for GCF compatibility

## Testing
- mvn -pl function test

------
https://chatgpt.com/codex/tasks/task_b_68de3ef43df88324acafc836156b82c7