### PR TITLE
Improve logging in legacy receipt parsing

### DIFF
--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
@@ -1,5 +1,6 @@
 package dev.pekelund.responsiveauth.function.legacy;
 
+import java.util.Arrays;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,6 +20,14 @@ class PdfParser {
     }
 
     LegacyParsedReceipt parse(String[] pdfData) {
+        if (pdfData == null || pdfData.length == 0) {
+            LOGGER.warn("Attempting to parse empty PDF data");
+        } else {
+            LOGGER.info("Parsing PDF data with {} lines", pdfData.length);
+            int sampleSize = Math.min(5, pdfData.length);
+            LOGGER.info("PDF data sample: {}", Arrays.toString(Arrays.copyOf(pdfData, sampleSize)));
+        }
+
         ReceiptFormat format = formatDetector.detectFormat(pdfData);
         LOGGER.info("Detected receipt format: {}", format);
 

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/ReceiptFormatDetector.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/ReceiptFormatDetector.java
@@ -16,10 +16,10 @@ public class ReceiptFormatDetector {
             return ReceiptFormat.UNKNOWN;
         }
 
-        if (LOGGER.isDebugEnabled()) {
-            int sampleSize = Math.min(5, pdfData.length);
-            LOGGER.debug("Receipt header sample: {}", Arrays.toString(Arrays.copyOf(pdfData, sampleSize)));
-        }
+        LOGGER.info("Detecting receipt format for PDF data with {} lines", pdfData.length);
+
+        int sampleSize = Math.min(5, pdfData.length);
+        LOGGER.info("Receipt header sample: {}", Arrays.toString(Arrays.copyOf(pdfData, sampleSize)));
 
         for (String line : pdfData) {
             if (line.contains("Kvittonr:")) {


### PR DESCRIPTION
## Summary
- log the size of the PDF data set and a header sample while detecting formats
- capture a short snippet of the parsed PDF content in the legacy parser to aid troubleshooting

## Testing
- Not run (Maven build hung during dependency resolution in the environment)


------
https://chatgpt.com/codex/tasks/task_b_68de8d0e203c8324911e959493a31066