### PR TITLE
Document local receipt parsing test server

### DIFF
--- a/function/pom.xml
+++ b/function/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-function-context</artifactId>
             <version>${spring-cloud-function.version}</version>
@@ -66,6 +71,11 @@
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
             <version>2.0.33</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/FunctionConfiguration.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/FunctionConfiguration.java
@@ -21,12 +21,14 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.StringUtils;
 import dev.pekelund.responsiveauth.function.legacy.LegacyPdfReceiptExtractor;
 
 @Configuration
+@Profile("!local-receipt-test")
 public class FunctionConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FunctionConfiguration.class);

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptParsingController.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptParsingController.java
@@ -1,0 +1,63 @@
+package dev.pekelund.responsiveauth.function.local;
+
+import dev.pekelund.responsiveauth.function.ReceiptDataExtractor;
+import dev.pekelund.responsiveauth.function.ReceiptExtractionResult;
+import dev.pekelund.responsiveauth.function.ReceiptParsingException;
+import java.io.IOException;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.multipart.MultipartFile;
+
+import org.springframework.context.annotation.Profile;
+
+@RestController
+@RequestMapping("/local-receipts")
+@Profile("local-receipt-test")
+public class LocalReceiptParsingController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalReceiptParsingController.class);
+
+    private final ReceiptDataExtractor receiptDataExtractor;
+
+    public LocalReceiptParsingController(ReceiptDataExtractor receiptDataExtractor) {
+        this.receiptDataExtractor = receiptDataExtractor;
+    }
+
+    @PostMapping(path = "/parse", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> parseReceipt(@RequestPart("file") MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of(
+                "error", "A non-empty PDF must be provided as the 'file' part"
+            ));
+        }
+
+        String fileName = StringUtils.hasText(file.getOriginalFilename()) ? file.getOriginalFilename() : "receipt.pdf";
+        LOGGER.info("Parsing receipt '{}' using local test server", fileName);
+        ReceiptExtractionResult result = receiptDataExtractor.extract(file.getBytes(), fileName);
+        LOGGER.info("Parsed receipt '{}' with {} structured fields", fileName, result.structuredData().size());
+        return ResponseEntity.ok(Map.of(
+            "structuredData", result.structuredData(),
+            "rawResponse", result.rawResponse()
+        ));
+    }
+
+    @ExceptionHandler(ReceiptParsingException.class)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public Map<String, Object> handleParsingException(ReceiptParsingException exception) {
+        LOGGER.warn("Receipt parsing failed: {}", exception.getMessage());
+        return Map.of(
+            "error", exception.getMessage()
+        );
+    }
+}

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptTestConfiguration.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptTestConfiguration.java
@@ -1,0 +1,27 @@
+package dev.pekelund.responsiveauth.function.local;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.pekelund.responsiveauth.function.ReceiptDataExtractor;
+import dev.pekelund.responsiveauth.function.legacy.LegacyPdfReceiptExtractor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("local-receipt-test")
+public class LocalReceiptTestConfiguration {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        return mapper;
+    }
+
+    @Bean
+    @Primary
+    public ReceiptDataExtractor receiptDataExtractor(LegacyPdfReceiptExtractor legacyPdfReceiptExtractor) {
+        return legacyPdfReceiptExtractor;
+    }
+}

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/HybridReceiptExtractorTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/HybridReceiptExtractorTest.java
@@ -1,0 +1,99 @@
+package dev.pekelund.responsiveauth.function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import dev.pekelund.responsiveauth.function.legacy.LegacyPdfReceiptExtractor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HybridReceiptExtractorTest {
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+    }
+
+    @Test
+    void usesLegacyResultWhenUsable() {
+        LegacyPdfReceiptExtractor legacyExtractor = mock(LegacyPdfReceiptExtractor.class);
+        AIReceiptExtractor aiExtractor = mock(AIReceiptExtractor.class);
+        ReceiptExtractionResult legacyResult = new ReceiptExtractionResult(
+            Map.of(
+                "general", Map.of(
+                    "format", "STANDARD",
+                    "totalAmount", new BigDecimal("19.98")),
+                "items", List.of(Map.of("name", "Milk"))),
+            "{\"general\":{}}"
+        );
+        doReturn(legacyResult).when(legacyExtractor).extract(any(), eq("sample.pdf"));
+
+        HybridReceiptExtractor extractor = new HybridReceiptExtractor(legacyExtractor, aiExtractor, objectMapper);
+        ReceiptExtractionResult result = extractor.extract(new byte[] {1, 2, 3}, "sample.pdf");
+
+        assertThat(result).isSameAs(legacyResult);
+        verify(aiExtractor, never()).extract(any(), any());
+    }
+
+    @Test
+    void fallsBackToAiWhenLegacyNotUsable() {
+        LegacyPdfReceiptExtractor legacyExtractor = mock(LegacyPdfReceiptExtractor.class);
+        AIReceiptExtractor aiExtractor = mock(AIReceiptExtractor.class);
+
+        ReceiptExtractionResult legacyResult = new ReceiptExtractionResult(
+            Map.of(
+                "general", Map.of("format", "UNKNOWN"),
+                "items", List.of()),
+            "{\"general\":{}}"
+        );
+        Map<String, Object> aiData = Map.of(
+            "general", Map.of("source", "ai"),
+            "items", List.of(Map.of("name", "Fallback"))
+        );
+        ReceiptExtractionResult aiResult = new ReceiptExtractionResult(aiData, "{\"general\":{\"source\":\"ai\"}}");
+
+        doReturn(legacyResult).when(legacyExtractor).extract(any(), eq("sample.pdf"));
+        doReturn(aiResult).when(aiExtractor).extract(any(), eq("sample.pdf"));
+
+        HybridReceiptExtractor extractor = new HybridReceiptExtractor(legacyExtractor, aiExtractor, objectMapper);
+        ReceiptExtractionResult result = extractor.extract(new byte[] {4, 5, 6}, "sample.pdf");
+
+        assertThat(result.structuredData()).containsEntry("source", "hybrid");
+        assertThat(result.structuredData()).containsEntry("primary", "gemini");
+        assertThat(result.structuredData()).containsEntry("legacy", legacyResult.structuredData());
+        assertThat(result.structuredData()).containsEntry("gemini", aiResult.structuredData());
+        verify(aiExtractor).extract(any(), eq("sample.pdf"));
+    }
+
+    @Test
+    void propagatesAiFailuresWhenLegacyAlsoFails() {
+        LegacyPdfReceiptExtractor legacyExtractor = mock(LegacyPdfReceiptExtractor.class);
+        AIReceiptExtractor aiExtractor = mock(AIReceiptExtractor.class);
+
+        doThrow(new ReceiptParsingException("legacy boom"))
+            .when(legacyExtractor).extract(any(), eq("sample.pdf"));
+        doThrow(new ReceiptParsingException("ai boom"))
+            .when(aiExtractor).extract(any(), eq("sample.pdf"));
+
+        HybridReceiptExtractor extractor = new HybridReceiptExtractor(legacyExtractor, aiExtractor, objectMapper);
+
+        assertThatThrownBy(() -> extractor.extract(new byte[] {7, 8, 9}, "sample.pdf"))
+            .isInstanceOf(ReceiptParsingException.class)
+            .hasMessageContaining("ai boom");
+        verify(aiExtractor).extract(any(), eq("sample.pdf"));
+    }
+}

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
@@ -1,0 +1,107 @@
+package dev.pekelund.responsiveauth.function.legacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.pekelund.responsiveauth.function.ReceiptExtractionResult;
+import dev.pekelund.responsiveauth.function.ReceiptParsingException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LegacyPdfReceiptExtractorTest {
+
+    private LegacyPdfReceiptExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+        ReceiptFormatDetector detector = new ReceiptFormatDetector();
+        PdfParser pdfParser = new PdfParser(List.of(new StandardFormatParser(), new NewFormatParser()), detector);
+        extractor = new LegacyPdfReceiptExtractor(pdfParser, objectMapper);
+    }
+
+    @Test
+    void parsesStandardReceiptPdf() throws IOException {
+        byte[] pdfBytes = createPdf("""
+            ICA KVANTUM
+            ICA Kvantum Testbutik
+            2024-09-30 12:34 AID:123456
+            Kvittonr: 123456789
+            Beskrivning Art. nr. Pris Mängd Summa(SEK)
+            Banan 7318690081055 10.00 1 st 10.00
+            Äpple 7318690081062 5.00 2 st 10.00
+            Moms % Moms Netto Brutto
+            Total 20.00
+            """);
+
+        ReceiptExtractionResult result = extractor.extract(pdfBytes, "sample.pdf");
+
+        assertThat(result.structuredData()).isNotNull();
+        Map<String, Object> general = getMap(result.structuredData().get("general"));
+        assertThat(general.get("format")).isEqualTo("STANDARD");
+        assertThat(new BigDecimal(general.get("totalAmount").toString()))
+            .isEqualByComparingTo(new BigDecimal("20.00"));
+        assertThat(general.get("fileName")).isEqualTo("sample.pdf");
+
+        List<Map<String, Object>> items = getList(result.structuredData().get("items"));
+        assertThat(items).hasSize(2);
+        assertThat(items.get(0)).containsEntry("name", "Banan");
+        assertThat(items.get(1)).containsEntry("name", "Äpple");
+
+        String rawText = (String) result.structuredData().get("rawText");
+        assertThat(rawText).contains("Beskrivning Art. nr. Pris Mängd Summa(SEK)");
+    }
+
+    @Test
+    void rejectsEmptyPdf() {
+        assertThatThrownBy(() -> extractor.extract(new byte[0], "empty.pdf"))
+            .isInstanceOf(ReceiptParsingException.class)
+            .hasMessageContaining("empty PDF");
+    }
+
+    private byte[] createPdf(String content) throws IOException {
+        try (PDDocument document = new PDDocument()) {
+            PDPage page = new PDPage(PDRectangle.A4);
+            document.addPage(page);
+            try (PDPageContentStream stream = new PDPageContentStream(document, page)) {
+                stream.setFont(PDType1Font.HELVETICA, 12);
+                stream.setLeading(14.5f);
+                stream.beginText();
+                stream.newLineAtOffset(50, 750);
+                for (String line : content.strip().split("\n")) {
+                    stream.showText(line.strip());
+                    stream.newLine();
+                }
+                stream.endText();
+            }
+            try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+                document.save(output);
+                return output.toByteArray();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getMap(Object value) {
+        assertThat(value).isInstanceOf(Map.class);
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> getList(Object value) {
+        assertThat(value).isInstanceOf(List.class);
+        return (List<Map<String, Object>>) value;
+    }
+}


### PR DESCRIPTION
## Summary
- add an optional Spring MVC stack and local profile that expose the legacy receipt parser through /local-receipts/parse
- guard the existing cloud function configuration so the local profile can boot without Firestore, Storage, or Vertex AI
- document how to launch the test server and send it a PDF for validation

## Testing
- ./mvnw -pl function test

------
https://chatgpt.com/codex/tasks/task_b_68de9933cf1483249279f838ae413945