### PR TITLE
Add noop chat model for local receipt testing

### DIFF
--- a/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptTestConfiguration.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptTestConfiguration.java
@@ -3,6 +3,7 @@ package dev.pekelund.responsiveauth.function.local;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.pekelund.responsiveauth.function.ReceiptDataExtractor;
 import dev.pekelund.responsiveauth.function.legacy.LegacyPdfReceiptExtractor;
+import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -23,5 +24,11 @@ public class LocalReceiptTestConfiguration {
     @Primary
     public ReceiptDataExtractor receiptDataExtractor(LegacyPdfReceiptExtractor legacyPdfReceiptExtractor) {
         return legacyPdfReceiptExtractor;
+    }
+
+    @Bean
+    @Primary
+    public ChatModel chatModel() {
+        return new NoopChatModel();
     }
 }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/local/NoopChatModel.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/local/NoopChatModel.java
@@ -1,0 +1,36 @@
+package dev.pekelund.responsiveauth.function.local;
+
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.DefaultChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import reactor.core.publisher.Flux;
+
+/**
+ * Minimal {@link ChatModel} implementation used for the {@code local-receipt-test}
+ * profile so that Spring AI auto-configuration backs off and we avoid depending
+ * on Vertex AI during local development.
+ */
+class NoopChatModel implements ChatModel {
+
+    private static final String DISABLED_MESSAGE =
+        "ChatModel is disabled for the local-receipt-test profile";
+
+    @Override
+    public ChatResponse call(Prompt prompt) {
+        throw new UnsupportedOperationException(DISABLED_MESSAGE);
+    }
+
+    @Override
+    public ChatOptions getDefaultOptions() {
+        DefaultChatOptions options = new DefaultChatOptions();
+        options.setModel("local-noop");
+        return options;
+    }
+
+    @Override
+    public Flux<ChatResponse> stream(Prompt prompt) {
+        return Flux.error(new UnsupportedOperationException(DISABLED_MESSAGE));
+    }
+}


### PR DESCRIPTION
## Summary
- provide a stub ChatModel bean when the `local-receipt-test` profile is active so that Spring AI auto-configuration does not require Vertex AI
- add a lightweight NoopChatModel implementation used only for local testing

## Testing
- `LOGGING_PROJECT_ID=local ./mvnw -pl function -am spring-boot:run -Dspring-boot.run.profiles=local-receipt-test` *(fails: Google Cloud logging requires a project id in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dea8af0aa8832488df27f0d9ba8348