### PR TITLE
Ensure local receipt testing profile runs with servlet container

### DIFF
--- a/function/src/main/resources/application-local-receipt-test.yml
+++ b/function/src/main/resources/application-local-receipt-test.yml
@@ -1,0 +1,3 @@
+spring:
+  main:
+    web-application-type: servlet


### PR DESCRIPTION
## Summary
- add a local receipt testing profile configuration that starts Spring Boot in servlet mode

## Testing
- not run (environment lacks cached Maven dependencies, initial download took too long)


------
https://chatgpt.com/codex/tasks/task_b_68ded567245083248daa6a04a55de3c1