### PR TITLE
Improve Swedish decimal handling and VAT termination

### DIFF
--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/CodexOnlyReceiptDataExtractor.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/CodexOnlyReceiptDataExtractor.java
@@ -1,0 +1,24 @@
+package dev.pekelund.responsiveauth.function.legacy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.pekelund.responsiveauth.function.ReceiptDataExtractor;
+import dev.pekelund.responsiveauth.function.ReceiptExtractionResult;
+import java.util.List;
+
+/**
+ * Receipt extractor that delegates to the Codex parser regardless of the detected format.
+ */
+public class CodexOnlyReceiptDataExtractor implements ReceiptDataExtractor {
+
+    private final LegacyPdfReceiptExtractor delegate;
+
+    public CodexOnlyReceiptDataExtractor(ObjectMapper objectMapper) {
+        PdfParser pdfParser = new PdfParser(List.of(new CodexParser()), new ReceiptFormatDetector());
+        this.delegate = new LegacyPdfReceiptExtractor(pdfParser, objectMapper);
+    }
+
+    @Override
+    public ReceiptExtractionResult extract(byte[] pdfBytes, String fileName) {
+        return delegate.extract(pdfBytes, fileName);
+    }
+}

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/CodexParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/CodexParser.java
@@ -1,0 +1,274 @@
+package dev.pekelund.responsiveauth.function.legacy;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(0)
+class CodexParser implements ReceiptFormatParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CodexParser.class);
+
+    private static final Pattern ITEM_PATTERN = Pattern.compile(
+        "^(?<name>.+?)\\s+(?<ean>\\d{8,13})\\s+(?<unit>-?\\d+,\\d{2})\\s+(?<quantity>\\d+(?:,\\d+)?\\s*\\p{L}+)\\s+(?<total>-?\\d+,\\d{2})$"
+    );
+    private static final Pattern DISCOUNT_PATTERN = Pattern.compile(
+        "^(?<description>.+?)\\s+(?<amount>-\\d+,\\d{2})$"
+    );
+    private static final Pattern VAT_HEADER_PATTERN = Pattern.compile(
+        "^Moms\\s*%\\s*Moms\\s*Netto\\s*Brutto$",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern VAT_LINE_PATTERN = Pattern.compile(
+        "^(?<rate>\\d+(?:,\\d+)?)\\s+(?<tax>-?\\d+,\\d{2})\\s+(?<net>-?\\d+,\\d{2})\\s+(?<gross>-?\\d+,\\d{2})$"
+    );
+    private static final Pattern TOTAL_PATTERN = Pattern.compile(
+        "^Betalat\\s+(?<amount>[-\\d,]+)$",
+        Pattern.CASE_INSENSITIVE
+    );
+    private static final Pattern DATE_PATTERN = Pattern.compile("^(?<date>\\d{4}-\\d{2}-\\d{2})$");
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    @Override
+    public boolean supportsFormat(ReceiptFormat format) {
+        return format == ReceiptFormat.NEW_FORMAT;
+    }
+
+    @Override
+    public LegacyParsedReceipt parse(String[] pdfData, ReceiptFormat format) {
+        String[] lines = pdfData == null ? new String[0] : pdfData;
+
+        String storeName = extractStoreName(lines);
+        LocalDate receiptDate = extractDate(lines);
+        BigDecimal totalAmount = null;
+
+        List<LegacyReceiptItem> items = new ArrayList<>();
+        List<LegacyReceiptVat> vats = new ArrayList<>();
+        List<LegacyReceiptError> errors = new ArrayList<>();
+
+        boolean inItems = false;
+        boolean inVat = false;
+        LegacyReceiptItem currentItem = null;
+
+        for (int index = 0; index < lines.length; index++) {
+            String originalLine = lines[index];
+            String line = sanitize(originalLine);
+            if (line.isEmpty()) {
+                continue;
+            }
+
+            if (VAT_HEADER_PATTERN.matcher(line).matches()) {
+                LOGGER.debug("Detected VAT section at line {}", index);
+                inItems = false;
+                inVat = true;
+                continue;
+            }
+
+            if (line.startsWith("Beskrivning")) {
+                LOGGER.debug("Detected item header at line {}", index);
+                inItems = true;
+                inVat = false;
+                continue;
+            }
+
+            if (line.startsWith("Betalningsinformation")
+                || line.startsWith("Erhållen rabatt")
+                || line.startsWith("Avrundning")
+                || line.startsWith("Kort")) {
+                inVat = false;
+            }
+
+            Matcher totalMatcher = TOTAL_PATTERN.matcher(line);
+            if (totalMatcher.matches()) {
+                BigDecimal amount = parseAmount(totalMatcher.group("amount"));
+                if (amount != null) {
+                    totalAmount = amount;
+                } else {
+                    errors.add(new LegacyReceiptError(index, originalLine, "Unable to parse total amount"));
+                }
+                inItems = false;
+                currentItem = null;
+                continue;
+            }
+
+            if (inItems) {
+                Matcher itemMatcher = ITEM_PATTERN.matcher(line);
+                if (itemMatcher.matches()) {
+                    LegacyReceiptItem item = createItem(itemMatcher);
+                    items.add(item);
+                    currentItem = item;
+                    continue;
+                }
+
+                Matcher discountMatcher = DISCOUNT_PATTERN.matcher(line);
+                if (discountMatcher.matches()) {
+                    String description = normalizeWhitespace(discountMatcher.group("description"));
+                    BigDecimal discountAmount = parseAmount(discountMatcher.group("amount"));
+                    if (discountAmount == null) {
+                        errors.add(new LegacyReceiptError(index, originalLine, "Unable to parse discount amount"));
+                        continue;
+                    }
+                    if (currentItem != null && currentItem.getTotalPrice() != null
+                        && discountAmount.abs().compareTo(currentItem.getTotalPrice().abs()) <= 0) {
+                        currentItem.addDiscount(new LegacyReceiptDiscount(description, discountAmount));
+                    } else {
+                        items.add(new LegacyReceiptItem(
+                            description,
+                            null,
+                            discountAmount,
+                            null,
+                            discountAmount
+                        ));
+                        currentItem = null;
+                    }
+                    continue;
+                }
+
+                errors.add(new LegacyReceiptError(index, originalLine, "Unrecognized item line"));
+                continue;
+            }
+
+            if (inVat) {
+                Matcher vatMatcher = VAT_LINE_PATTERN.matcher(line);
+                if (vatMatcher.matches()) {
+                    LegacyReceiptVat vat = createVat(vatMatcher);
+                    if (vat != null) {
+                        vats.add(vat);
+                    } else {
+                        errors.add(new LegacyReceiptError(index, originalLine, "Unable to parse VAT line"));
+                    }
+                    continue;
+                }
+
+                if (!line.startsWith("Moms")) {
+                    inVat = false;
+                }
+            }
+        }
+
+        return new LegacyParsedReceipt(format, storeName, receiptDate, totalAmount, items, vats, errors);
+    }
+
+    private String extractStoreName(String[] lines) {
+        boolean seenHeader = false;
+        for (String raw : lines) {
+            String line = sanitize(raw);
+            if (line.isEmpty()) {
+                continue;
+            }
+            if (!seenHeader && line.equalsIgnoreCase("Kvitto")) {
+                seenHeader = true;
+                continue;
+            }
+            if (seenHeader && !line.isEmpty()) {
+                return line;
+            }
+        }
+        for (String raw : lines) {
+            String line = sanitize(raw);
+            if (!line.isEmpty()) {
+                return line;
+            }
+        }
+        return null;
+    }
+
+    private LocalDate extractDate(String[] lines) {
+        for (String raw : lines) {
+            String line = sanitize(raw);
+            Matcher matcher = DATE_PATTERN.matcher(line);
+            if (matcher.matches()) {
+                try {
+                    return LocalDate.parse(matcher.group("date"), DATE_FORMATTER);
+                } catch (Exception ex) {
+                    LOGGER.debug("Unable to parse date '{}'", line, ex);
+                }
+            }
+        }
+        return null;
+    }
+
+    private LegacyReceiptItem createItem(Matcher matcher) {
+        String name = normalizeWhitespace(matcher.group("name"));
+        String ean = matcher.group("ean");
+        BigDecimal unitPrice = parseAmount(matcher.group("unit"));
+        String quantity = normalizeQuantity(matcher.group("quantity"));
+        BigDecimal totalPrice = parseAmount(matcher.group("total"));
+        return new LegacyReceiptItem(name, ean, unitPrice, quantity, totalPrice);
+    }
+
+    private LegacyReceiptVat createVat(Matcher matcher) {
+        BigDecimal rate = parseAmount(matcher.group("rate"));
+        BigDecimal tax = parseAmount(matcher.group("tax"));
+        BigDecimal net = parseAmount(matcher.group("net"));
+        BigDecimal gross = parseAmount(matcher.group("gross"));
+        if (rate == null || tax == null || net == null || gross == null) {
+            return null;
+        }
+        return new LegacyReceiptVat(rate, tax, net, gross);
+    }
+
+    private String sanitize(String line) {
+        if (line == null) {
+            return "";
+        }
+        return line.replace('\u00A0', ' ').trim();
+    }
+
+    private String normalizeWhitespace(String value) {
+        return value == null ? null : value.replace('\u00A0', ' ').trim().replaceAll("\\s+", " ");
+    }
+
+    private String normalizeQuantity(String value) {
+        return value == null ? null : value.replace('\u00A0', ' ').trim().replaceAll("\\s+", " ");
+    }
+
+    private BigDecimal parseAmount(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.replace('\u00A0', ' ').trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        boolean negative = trimmed.startsWith("-");
+        boolean positive = trimmed.startsWith("+");
+        String digits = trimmed.replaceAll("[^0-9,]", "");
+        if (digits.isEmpty()) {
+            return null;
+        }
+        int lastComma = digits.lastIndexOf(',');
+        String integerPart;
+        String decimalPart = "";
+        if (lastComma >= 0) {
+            integerPart = digits.substring(0, lastComma).replace(",", "");
+            decimalPart = digits.substring(lastComma + 1);
+        } else {
+            integerPart = digits.replace(",", "");
+        }
+        if (integerPart.isEmpty()) {
+            integerPart = "0";
+        }
+        StringBuilder number = new StringBuilder(integerPart);
+        if (!decimalPart.isEmpty()) {
+            number.append('.').append(decimalPart);
+        }
+        BigDecimal amount = new BigDecimal(number.toString());
+        if (negative) {
+            amount = amount.negate();
+        } else if (positive) {
+            return amount;
+        }
+        return amount;
+    }
+}

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/CodexParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/CodexParser.java
@@ -9,12 +9,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
-
-@Component
-@Order(0)
-class CodexParser implements ReceiptFormatParser {
+public class CodexParser implements ReceiptFormatParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CodexParser.class);
 

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyParsedReceipt.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyParsedReceipt.java
@@ -10,10 +10,12 @@ public record LegacyParsedReceipt(
     LocalDate receiptDate,
     BigDecimal totalAmount,
     List<LegacyReceiptItem> items,
+    List<LegacyReceiptVat> vats,
     List<LegacyReceiptError> errors
 ) {
     public LegacyParsedReceipt {
         items = items == null ? List.of() : List.copyOf(items);
+        vats = vats == null ? List.of() : List.copyOf(vats);
         errors = errors == null ? List.of() : List.copyOf(errors);
     }
 }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractor.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractor.java
@@ -75,6 +75,10 @@ public class LegacyPdfReceiptExtractor implements ReceiptDataExtractor {
             .map(this::mapItem)
             .collect(Collectors.toCollection(ArrayList::new));
 
+        List<Map<String, Object>> vats = parsedReceipt.vats().stream()
+            .map(this::mapVat)
+            .collect(Collectors.toCollection(ArrayList::new));
+
         List<Map<String, Object>> errors = parsedReceipt.errors().stream()
             .map(error -> Map.<String, Object>of(
                 "lineNumber", error.lineNumber(),
@@ -85,6 +89,7 @@ public class LegacyPdfReceiptExtractor implements ReceiptDataExtractor {
         Map<String, Object> structuredData = new LinkedHashMap<>();
         structuredData.put("general", general);
         structuredData.put("items", items);
+        structuredData.put("vats", vats);
         structuredData.put("errors", errors);
         structuredData.put("rawText", String.join("\n", pdfData));
         structuredData.put("source", SOURCE);
@@ -104,6 +109,15 @@ public class LegacyPdfReceiptExtractor implements ReceiptDataExtractor {
                 "amount", discount.amount()))
             .collect(Collectors.toCollection(ArrayList::new));
         mapped.put("discounts", discounts);
+        return mapped;
+    }
+
+    private Map<String, Object> mapVat(LegacyReceiptVat vat) {
+        Map<String, Object> mapped = new LinkedHashMap<>();
+        mapped.put("rate", vat.rate());
+        mapped.put("taxAmount", vat.taxAmount());
+        mapped.put("netAmount", vat.netAmount());
+        mapped.put("grossAmount", vat.grossAmount());
         return mapped;
     }
 

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyReceiptItem.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyReceiptItem.java
@@ -5,21 +5,21 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public final class LegacyReceiptItem {
+public record LegacyReceiptItem(
+    String name,
+    String eanCode,
+    BigDecimal unitPrice,
+    String quantity,
+    BigDecimal totalPrice,
+    List<LegacyReceiptDiscount> discounts
+) {
 
-    private final String name;
-    private final String eanCode;
-    private final BigDecimal unitPrice;
-    private final String quantity;
-    private final BigDecimal totalPrice;
-    private final List<LegacyReceiptDiscount> discounts = new ArrayList<>();
+    public LegacyReceiptItem {
+        discounts = discounts == null ? new ArrayList<>() : new ArrayList<>(discounts);
+    }
 
     public LegacyReceiptItem(String name, String eanCode, BigDecimal unitPrice, String quantity, BigDecimal totalPrice) {
-        this.name = name;
-        this.eanCode = eanCode;
-        this.unitPrice = unitPrice;
-        this.quantity = quantity;
-        this.totalPrice = totalPrice;
+        this(name, eanCode, unitPrice, quantity, totalPrice, new ArrayList<>());
     }
 
     public String getName() {
@@ -43,12 +43,17 @@ public final class LegacyReceiptItem {
     }
 
     public List<LegacyReceiptDiscount> getDiscounts() {
-        return Collections.unmodifiableList(discounts);
+        return Collections.unmodifiableList(this.discounts);
+    }
+
+    @Override
+    public List<LegacyReceiptDiscount> discounts() {
+        return getDiscounts();
     }
 
     public void addDiscount(LegacyReceiptDiscount discount) {
         if (discount != null) {
-            discounts.add(discount);
+            this.discounts.add(discount);
         }
     }
 }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyReceiptVat.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyReceiptVat.java
@@ -1,0 +1,11 @@
+package dev.pekelund.responsiveauth.function.legacy;
+
+import java.math.BigDecimal;
+
+public record LegacyReceiptVat(
+    BigDecimal rate,
+    BigDecimal taxAmount,
+    BigDecimal netAmount,
+    BigDecimal grossAmount
+) {
+}

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
@@ -42,6 +42,6 @@ class PdfParser {
             format == ReceiptFormat.UNKNOWN
                 ? "Unable to determine receipt format"
                 : "No parser registered for format " + format);
-        return new LegacyParsedReceipt(format, null, null, null, List.of(), List.of(error));
+        return new LegacyParsedReceipt(format, null, null, null, List.of(), List.of(), List.of(error));
     }
 }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
@@ -7,14 +7,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
-class PdfParser {
+public class PdfParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PdfParser.class);
 
     private final List<ReceiptFormatParser> formatParsers;
     private final ReceiptFormatDetector formatDetector;
 
-    PdfParser(List<ReceiptFormatParser> formatParsers, ReceiptFormatDetector formatDetector) {
+    public PdfParser(List<ReceiptFormatParser> formatParsers, ReceiptFormatDetector formatDetector) {
         this.formatParsers = formatParsers;
         this.formatDetector = formatDetector;
     }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptParsingController.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptParsingController.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -15,8 +16,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import org.springframework.context.annotation.Profile;
@@ -29,27 +30,22 @@ public class LocalReceiptParsingController {
     private static final Logger LOGGER = LoggerFactory.getLogger(LocalReceiptParsingController.class);
 
     private final ReceiptDataExtractor receiptDataExtractor;
+    private final ReceiptDataExtractor codexReceiptDataExtractor;
 
-    public LocalReceiptParsingController(ReceiptDataExtractor receiptDataExtractor) {
+    public LocalReceiptParsingController(ReceiptDataExtractor receiptDataExtractor,
+        @Qualifier("codexReceiptDataExtractor") ReceiptDataExtractor codexReceiptDataExtractor) {
         this.receiptDataExtractor = receiptDataExtractor;
+        this.codexReceiptDataExtractor = codexReceiptDataExtractor;
     }
 
     @PostMapping(path = "/parse", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, Object>> parseReceipt(@RequestPart("file") MultipartFile file) throws IOException {
-        if (file == null || file.isEmpty()) {
-            return ResponseEntity.badRequest().body(Map.of(
-                "error", "A non-empty PDF must be provided as the 'file' part"
-            ));
-        }
+        return parseReceiptInternal(file, receiptDataExtractor, "legacy");
+    }
 
-        String fileName = StringUtils.hasText(file.getOriginalFilename()) ? file.getOriginalFilename() : "receipt.pdf";
-        LOGGER.info("Parsing receipt '{}' using local test server", fileName);
-        ReceiptExtractionResult result = receiptDataExtractor.extract(file.getBytes(), fileName);
-        LOGGER.info("Parsed receipt '{}' with {} structured fields", fileName, result.structuredData().size());
-        return ResponseEntity.ok(Map.of(
-            "structuredData", result.structuredData(),
-            "rawResponse", result.rawResponse()
-        ));
+    @PostMapping(path = "/parse-codex", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> parseReceiptCodex(@RequestPart("file") MultipartFile file) throws IOException {
+        return parseReceiptInternal(file, codexReceiptDataExtractor, "codex");
     }
 
     @ExceptionHandler(ReceiptParsingException.class)
@@ -59,5 +55,24 @@ public class LocalReceiptParsingController {
         return Map.of(
             "error", exception.getMessage()
         );
+    }
+
+    private ResponseEntity<Map<String, Object>> parseReceiptInternal(MultipartFile file, ReceiptDataExtractor extractor,
+        String extractorName) throws IOException {
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of(
+                "error", "A non-empty PDF must be provided as the 'file' part"
+            ));
+        }
+
+        String fileName = StringUtils.hasText(file.getOriginalFilename()) ? file.getOriginalFilename() : "receipt.pdf";
+        LOGGER.info("Parsing receipt '{}' using {} extractor", fileName, extractorName);
+        ReceiptExtractionResult result = extractor.extract(file.getBytes(), fileName);
+        LOGGER.info("Parsed receipt '{}' with {} structured fields via {} extractor", fileName,
+            result.structuredData().size(), extractorName);
+        return ResponseEntity.ok(Map.of(
+            "structuredData", result.structuredData(),
+            "rawResponse", result.rawResponse()
+        ));
     }
 }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptTestConfiguration.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/local/LocalReceiptTestConfiguration.java
@@ -2,6 +2,7 @@ package dev.pekelund.responsiveauth.function.local;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.pekelund.responsiveauth.function.ReceiptDataExtractor;
+import dev.pekelund.responsiveauth.function.legacy.CodexOnlyReceiptDataExtractor;
 import dev.pekelund.responsiveauth.function.legacy.LegacyPdfReceiptExtractor;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.context.annotation.Bean;
@@ -24,6 +25,11 @@ public class LocalReceiptTestConfiguration {
     @Primary
     public ReceiptDataExtractor receiptDataExtractor(LegacyPdfReceiptExtractor legacyPdfReceiptExtractor) {
         return legacyPdfReceiptExtractor;
+    }
+
+    @Bean(name = "codexReceiptDataExtractor")
+    public ReceiptDataExtractor codexReceiptDataExtractor(ObjectMapper objectMapper) {
+        return new CodexOnlyReceiptDataExtractor(objectMapper);
     }
 
     @Bean

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/CodexParserTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/CodexParserTest.java
@@ -1,0 +1,152 @@
+package dev.pekelund.responsiveauth.function.legacy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CodexParserTest {
+
+    private final CodexParser parser = new CodexParser();
+
+    @Test
+    void parsesLargeSwedishReceipt() {
+        String[] lines = RECEIPT_TEXT.split("\\n");
+
+        LegacyParsedReceipt receipt = parser.parse(lines, ReceiptFormat.NEW_FORMAT);
+
+        assertThat(receipt.format()).isEqualTo(ReceiptFormat.NEW_FORMAT);
+        assertThat(receipt.storeName()).isEqualTo("ICA Kvantum Emporia");
+        assertThat(receipt.receiptDate()).isEqualTo(LocalDate.of(2025, 10, 2));
+        assertThat(receipt.totalAmount()).isEqualByComparingTo(new BigDecimal("1269.43"));
+
+        List<LegacyReceiptItem> items = receipt.items();
+        assertThat(items).hasSize(38);
+
+        LegacyReceiptItem first = items.get(0);
+        assertThat(first.getName()).isEqualTo("Broccoli filmad");
+        assertThat(first.getEanCode()).isEqualTo("7318690662952");
+        assertThat(first.getQuantity()).isEqualTo("2,00 st");
+        assertThat(first.getTotalPrice()).isEqualByComparingTo(new BigDecimal("41.90"));
+
+        LegacyReceiptItem gurka = items.stream()
+            .filter(item -> item.getName().contains("Gurka"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(gurka.getDiscounts()).singleElement()
+            .satisfies(discount -> {
+                assertThat(discount.description()).isEqualTo("2 för 30:-");
+                assertThat(discount.amount()).isEqualByComparingTo(new BigDecimal("-5.90"));
+            });
+
+        LegacyReceiptItem familyDiscount = items.stream()
+            .filter(item -> item.getName().equals("Familjerabatt"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(familyDiscount.getTotalPrice()).isEqualByComparingTo(new BigDecimal("-66.81"));
+
+        assertThat(receipt.vats()).hasSize(2);
+        assertThat(receipt.vats().get(0).rate()).isEqualByComparingTo(new BigDecimal("12.00"));
+        assertThat(receipt.vats().get(0).taxAmount()).isEqualByComparingTo(new BigDecimal("128.60"));
+
+        assertThat(receipt.errors()).isEmpty();
+    }
+
+    private static final String RECEIPT_TEXT = String.join("\n",
+        "Kvitto",
+        "ICA Kvantum Emporia",
+        "Hyllie stations väg 22",
+        "21532 Malmö",
+        "ICA KVANTUM MALMBORGS EMPORIA",
+        "HYLLIE STATIONSVÄG 22",
+        "215 32 MALMÖ",
+        "Tel.nr. 040 - 651 80 00",
+        "Org.nr. 559329-8556",
+        "Datum",
+        "Tid",
+        "Org nr",
+        "Kvitto nr",
+        "Kassa",
+        "Kassör",
+        "2025-10-02",
+        "20:20",
+        "SE559329855601",
+        "7800",
+        "55",
+        "1231231231",
+        "Beskrivning Artikelnummer Pris Mängd Summa(SEK)",
+        "Broccoli filmad 7318690662952 20,95 2,00 st 41,90",
+        "Eko Mellanmjö 1,5% 7310867501583 26,95 2,00 st 53,90",
+        "Filet Pieces 8445290003027 92,00 1,00 st 92,00",
+        "Fisherm salm sf 50357116 12,95 1,00 st 12,95",
+        "Fransk lantsalami 2000765300000 590,00 1,00 st 15,34",
+        "Fuet 7350027793915 46,95 1,00 st 46,95",
+        "GodM Äpplejuice 7310865081650 44,95 2,00 st 89,90",
+        "*Gurka 2092459500000 14,25 2,00 st 35,90",
+        "2 för 30:-  -5,90",
+        "Ingefära 2092461200000 34,95 1,00 st 2,38",
+        "Jamón Serrano 7331631007667 89,00 1,00 st 89,00",
+        "Koriander 7350018560649 32,95 1,00 st 32,95",
+        "Kål Vit Färsk 2092305100000 14,95 1,00 st 29,42",
+        "*Lime 2092404800000 3,17 3,00 st 17,85",
+        "3 för 10:-  -7,85",
+        "Lösviktsgodis 2000136300000 129,00 1,00 st 19,09",
+        "Mild Vaniljyog Pär 7310867512282 28,95 1,00 st 28,95",
+        "Mozzarella 21% Riv 7311875904342 74,95 1,00 st 74,95",
+        "Näsdukar 10p 7318690170501 13,95 1,00 st 13,95",
+        "Panaeng curry mild 7311520010862 39,95 1,00 st 39,95",
+        "Peppar Röd 2092469700000 4,95 2,00 st 9,90",
+        "Pizza Kit 3392590601536 33,95 2,00 st 67,90",
+        "Potatis fast 2092472800000 15,95 1,00 st 9,54",
+        "Purjolök 2092462900000 24,95 1,00 st 12,48",
+        "*Ravioli Tomat/Mozz 8001665700030 26,12 1,00 st 50,95",
+        "Rana generell 5 kr  -5,00",
+        "Rosor 5708870101029 59,00 1,00 st 59,00",
+        "*Smör normalsaltat 7310865005168 52,25 1,00 st 74,95",
+        "55:- Max 1  -19,95",
+        "Snabbmakaroner 7310130003554 24,95 1,00 st 24,95",
+        "Stillahavsspätta 5700001859786 35,95 2,00 st 71,90",
+        "Svartrökt skinka 2000752300000 240,00 1,00 st 30,24",
+        "Sweet chili sauce 8850058004657 34,95 1,00 st 34,95",
+        "Teriyaki Sauce 7311310035341 47,95 1,00 st 47,95",
+        "*Tomat Piccolini 7318690013563 19,00 1,00 st 35,95",
+        "Scanning 20:- Max 1  -15,95",
+        "*Tortelloni Svamp 8001665128698 30,87 1,00 st 50,95",
+        "2 för 65:-  -36,90",
+        "*Vanilj jordgubbsås 8711327462076 0,00 1,00 st 15,95",
+        "GLASS  -15,95",
+        "Vetekaka 24-p 7311800009531 34,95 1,00 st 34,95",
+        "Vispgrädde 40% 7310867003339 24,95 1,00 st 24,95",
+        "Wok Thai Style 7310500187150 28,95 1,00 st 28,95",
+        "Yogh Van/blåb 2,5% 7310867512831 20,00 1,00 st 20,00",
+        "Familjerabatt  -66,81",
+        "Betalat 1269,43",
+        "Moms % Moms Netto Brutto",
+        "12,00 128,60 1071,46 1200,06",
+        "25,00 13,87 55,50 69,37",
+        "Erhållen rabatt -174,31",
+        "Avrundning 0,00",
+        "Kort 1269,43",
+        "Betalningsinformation",
+        "Term:1710026528      SWE:9847583",
+        "Visa Credit          ************0490",
+        "Butik:13771 ",
+        "2025-10-02 20:19     AID:A0000000031010",
+        "TVR:0000000000       TSI:0000",
+        "Ref:002652874423 002 Rsp:00 199434 K-1 7",
+        "Visa Contactless",
+        "Verifierat av enhet",
+        "Köp         1,269,43",
+        "Varav moms    142,47",
+        "Totalt SEK  1,269,43",
+        "Spara kvittot",
+        "INGEN BYTESRÄTT PÅ",
+        "KYL- OCH FRYSVAROR",
+        "TACK FÖR BESÖKET!",
+        "VÄLKOMMEN ÅTER",
+        "Returkod",
+        "4401377155002477911002253"
+    );
+}

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/CodexParserTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/CodexParserTest.java
@@ -20,38 +20,84 @@ class CodexParserTest {
         assertThat(receipt.format()).isEqualTo(ReceiptFormat.NEW_FORMAT);
         assertThat(receipt.storeName()).isEqualTo("ICA Kvantum Emporia");
         assertThat(receipt.receiptDate()).isEqualTo(LocalDate.of(2025, 10, 2));
-        assertThat(receipt.totalAmount()).isEqualByComparingTo(new BigDecimal("1269.43"));
-
-        List<LegacyReceiptItem> items = receipt.items();
-        assertThat(items).hasSize(38);
-
-        LegacyReceiptItem first = items.get(0);
-        assertThat(first.getName()).isEqualTo("Broccoli filmad");
-        assertThat(first.getEanCode()).isEqualTo("7318690662952");
-        assertThat(first.getQuantity()).isEqualTo("2,00 st");
-        assertThat(first.getTotalPrice()).isEqualByComparingTo(new BigDecimal("41.90"));
-
-        LegacyReceiptItem gurka = items.stream()
-            .filter(item -> item.getName().contains("Gurka"))
-            .findFirst()
-            .orElseThrow();
-        assertThat(gurka.getDiscounts()).singleElement()
-            .satisfies(discount -> {
-                assertThat(discount.description()).isEqualTo("2 för 30:-");
-                assertThat(discount.amount()).isEqualByComparingTo(new BigDecimal("-5.90"));
-            });
-
-        LegacyReceiptItem familyDiscount = items.stream()
-            .filter(item -> item.getName().equals("Familjerabatt"))
-            .findFirst()
-            .orElseThrow();
-        assertThat(familyDiscount.getTotalPrice()).isEqualByComparingTo(new BigDecimal("-66.81"));
-
-        assertThat(receipt.vats()).hasSize(2);
-        assertThat(receipt.vats().get(0).rate()).isEqualByComparingTo(new BigDecimal("12.00"));
-        assertThat(receipt.vats().get(0).taxAmount()).isEqualByComparingTo(new BigDecimal("128.60"));
-
+        assertThat(receipt.totalAmount()).isEqualByComparingTo(amount("1269.43"));
         assertThat(receipt.errors()).isEmpty();
+
+        assertThat(receipt.items()).containsExactlyElementsOf(expectedItems());
+
+        assertThat(receipt.vats()).containsExactly(
+            new LegacyReceiptVat(amount("12.00"), amount("128.60"), amount("1071.46"), amount("1200.06")),
+            new LegacyReceiptVat(amount("25.00"), amount("13.87"), amount("55.50"), amount("69.37"))
+        );
+    }
+
+    private List<LegacyReceiptItem> expectedItems() {
+        return List.of(
+            item("Broccoli filmad", "7318690662952", "20.95", "2,00 st", "41.90"),
+            item("Eko Mellanmjö 1,5%", "7310867501583", "26.95", "2,00 st", "53.90"),
+            item("Filet Pieces", "8445290003027", "92.00", "1,00 st", "92.00"),
+            item("Fisherm salm sf", "50357116", "12.95", "1,00 st", "12.95"),
+            item("Fransk lantsalami", "2000765300000", "590.00", "1,00 st", "15.34"),
+            item("Fuet", "7350027793915", "46.95", "1,00 st", "46.95"),
+            item("GodM Äpplejuice", "7310865081650", "44.95", "2,00 st", "89.90"),
+            item("*Gurka", "2092459500000", "14.25", "2,00 st", "35.90", discount("2 för 30:-", "-5.90")),
+            item("Ingefära", "2092461200000", "34.95", "1,00 st", "2.38"),
+            item("Jamón Serrano", "7331631007667", "89.00", "1,00 st", "89.00"),
+            item("Koriander", "7350018560649", "32.95", "1,00 st", "32.95"),
+            item("Kål Vit Färsk", "2092305100000", "14.95", "1,00 st", "29.42"),
+            item("*Lime", "2092404800000", "3.17", "3,00 st", "17.85", discount("3 för 10:-", "-7.85")),
+            item("Lösviktsgodis", "2000136300000", "129.00", "1,00 st", "19.09"),
+            item("Mild Vaniljyog Pär", "7310867512282", "28.95", "1,00 st", "28.95"),
+            item("Mozzarella 21% Riv", "7311875904342", "74.95", "1,00 st", "74.95"),
+            item("Näsdukar 10p", "7318690170501", "13.95", "1,00 st", "13.95"),
+            item("Panaeng curry mild", "7311520010862", "39.95", "1,00 st", "39.95"),
+            item("Peppar Röd", "2092469700000", "4.95", "2,00 st", "9.90"),
+            item("Pizza Kit", "3392590601536", "33.95", "2,00 st", "67.90"),
+            item("Potatis fast", "2092472800000", "15.95", "1,00 st", "9.54"),
+            item("Purjolök", "2092462900000", "24.95", "1,00 st", "12.48"),
+            item("*Ravioli Tomat/Mozz", "8001665700030", "26.12", "1,00 st", "50.95", discount("Rana generell 5 kr", "-5.00")),
+            item("Rosor", "5708870101029", "59.00", "1,00 st", "59.00"),
+            item("*Smör normalsaltat", "7310865005168", "52.25", "1,00 st", "74.95", discount("55:- Max 1", "-19.95")),
+            item("Snabbmakaroner", "7310130003554", "24.95", "1,00 st", "24.95"),
+            item("Stillahavsspätta", "5700001859786", "35.95", "2,00 st", "71.90"),
+            item("Svartrökt skinka", "2000752300000", "240.00", "1,00 st", "30.24"),
+            item("Sweet chili sauce", "8850058004657", "34.95", "1,00 st", "34.95"),
+            item("Teriyaki Sauce", "7311310035341", "47.95", "1,00 st", "47.95"),
+            item("*Tomat Piccolini", "7318690013563", "19.00", "1,00 st", "35.95", discount("Scanning 20:- Max 1", "-15.95")),
+            item("*Tortelloni Svamp", "8001665128698", "30.87", "1,00 st", "50.95", discount("2 för 65:-", "-36.90")),
+            item("*Vanilj jordgubbsås", "8711327462076", "0.00", "1,00 st", "15.95", discount("GLASS", "-15.95")),
+            item("Vetekaka 24-p", "7311800009531", "34.95", "1,00 st", "34.95"),
+            item("Vispgrädde 40%", "7310867003339", "24.95", "1,00 st", "24.95"),
+            item("Wok Thai Style", "7310500187150", "28.95", "1,00 st", "28.95"),
+            item("Yogh Van/blåb 2,5%", "7310867512831", "20.00", "1,00 st", "20.00"),
+            item("Familjerabatt", null, "-66.81", null, "-66.81")
+        );
+    }
+
+    private LegacyReceiptItem item(
+        String name,
+        String ean,
+        String unitPrice,
+        String quantity,
+        String totalPrice,
+        LegacyReceiptDiscount... discounts
+    ) {
+        return new LegacyReceiptItem(
+            name,
+            ean,
+            unitPrice == null ? null : amount(unitPrice),
+            quantity,
+            totalPrice == null ? null : amount(totalPrice),
+            discounts.length == 0 ? List.of() : List.of(discounts)
+        );
+    }
+
+    private LegacyReceiptDiscount discount(String description, String amount) {
+        return new LegacyReceiptDiscount(description, amount(amount));
+    }
+
+    private BigDecimal amount(String value) {
+        return new BigDecimal(value);
     }
 
     private static final String RECEIPT_TEXT = String.join("\n",

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
@@ -28,7 +28,9 @@ class LegacyPdfReceiptExtractorTest {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.findAndRegisterModules();
         ReceiptFormatDetector detector = new ReceiptFormatDetector();
-        PdfParser pdfParser = new PdfParser(List.of(new StandardFormatParser(), new NewFormatParser()), detector);
+        PdfParser pdfParser = new PdfParser(
+            List.of(new StandardFormatParser(), new CodexParser(), new NewFormatParser()),
+            detector);
         extractor = new LegacyPdfReceiptExtractor(pdfParser, objectMapper);
     }
 

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
@@ -29,7 +29,7 @@ class LegacyPdfReceiptExtractorTest {
         objectMapper.findAndRegisterModules();
         ReceiptFormatDetector detector = new ReceiptFormatDetector();
         PdfParser pdfParser = new PdfParser(
-            List.of(new StandardFormatParser(), new CodexParser(), new NewFormatParser()),
+            List.of(new StandardFormatParser(), new NewFormatParser()),
             detector);
         extractor = new LegacyPdfReceiptExtractor(pdfParser, objectMapper);
     }


### PR DESCRIPTION
## Summary
- normalize numeric parsing to treat comma decimals and Swedish grouping consistently in the base parser
- stop item collection when encountering Betalat lines and tighten VAT section terminators for both receipt formats
- exit VAT parsing when reaching discount or payment footers so Swedish receipts with extra totals are captured cleanly

## Testing
- `./mvnw -pl function test`


------
https://chatgpt.com/codex/tasks/task_b_68df914fbed48324b9b469f300aef792