### PR TITLE
Handle Familjerabatt as receipt-level discount in Codex parser

### DIFF
--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/CodexParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/CodexParser.java
@@ -49,6 +49,7 @@ public class CodexParser implements ReceiptFormatParser {
 
         List<LegacyReceiptItem> items = new ArrayList<>();
         List<LegacyReceiptVat> vats = new ArrayList<>();
+        List<LegacyReceiptDiscount> generalDiscounts = new ArrayList<>();
         List<LegacyReceiptError> errors = new ArrayList<>();
 
         boolean inItems = false;
@@ -117,13 +118,7 @@ public class CodexParser implements ReceiptFormatParser {
                         && discountAmount.abs().compareTo(currentItem.getTotalPrice().abs()) <= 0) {
                         currentItem.addDiscount(new LegacyReceiptDiscount(description, discountAmount));
                     } else {
-                        items.add(new LegacyReceiptItem(
-                            description,
-                            null,
-                            discountAmount,
-                            null,
-                            discountAmount
-                        ));
+                        generalDiscounts.add(new LegacyReceiptDiscount(description, discountAmount));
                         currentItem = null;
                     }
                     continue;
@@ -151,7 +146,7 @@ public class CodexParser implements ReceiptFormatParser {
             }
         }
 
-        return new LegacyParsedReceipt(format, storeName, receiptDate, totalAmount, items, vats, errors);
+        return new LegacyParsedReceipt(format, storeName, receiptDate, totalAmount, items, vats, generalDiscounts, errors);
     }
 
     private String extractStoreName(String[] lines) {

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyParsedReceipt.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/LegacyParsedReceipt.java
@@ -11,11 +11,13 @@ public record LegacyParsedReceipt(
     BigDecimal totalAmount,
     List<LegacyReceiptItem> items,
     List<LegacyReceiptVat> vats,
+    List<LegacyReceiptDiscount> generalDiscounts,
     List<LegacyReceiptError> errors
 ) {
     public LegacyParsedReceipt {
         items = items == null ? List.of() : List.copyOf(items);
         vats = vats == null ? List.of() : List.copyOf(vats);
+        generalDiscounts = generalDiscounts == null ? List.of() : List.copyOf(generalDiscounts);
         errors = errors == null ? List.of() : List.copyOf(errors);
     }
 }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/NewFormatParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/NewFormatParser.java
@@ -78,7 +78,7 @@ class NewFormatParser extends BaseReceiptParser {
 
         LOGGER.info("Parsed NEW_FORMAT receipt - store: {}, date: {}, total: {}, items: {}, vat lines: {}", store,
             receiptDate, totalAmount, items.size(), vats.size());
-        return new LegacyParsedReceipt(format, store, receiptDate, totalAmount, items, vats, errors);
+        return new LegacyParsedReceipt(format, store, receiptDate, totalAmount, items, vats, List.of(), errors);
     }
 
     private Optional<LocalDate> extractDate(String[] pdfData) {

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
@@ -42,6 +42,6 @@ public class PdfParser {
             format == ReceiptFormat.UNKNOWN
                 ? "Unable to determine receipt format"
                 : "No parser registered for format " + format);
-        return new LegacyParsedReceipt(format, null, null, null, List.of(), List.of(), List.of(error));
+        return new LegacyParsedReceipt(format, null, null, null, List.of(), List.of(), List.of(), List.of(error));
     }
 }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/StandardFormatParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/StandardFormatParser.java
@@ -97,7 +97,7 @@ class StandardFormatParser extends BaseReceiptParser {
 
         LOGGER.info("Parsed STANDARD receipt - store: {}, date: {}, total: {}, items: {}, vat lines: {}", store,
             receiptDate, totalAmount, items.size(), vats.size());
-        return new LegacyParsedReceipt(format, store, receiptDate, totalAmount, items, vats, errors);
+        return new LegacyParsedReceipt(format, store, receiptDate, totalAmount, items, vats, List.of(), errors);
     }
 
     private Optional<BigDecimal> extractTotalAmount(String[] pdfData) {

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/CodexParserTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/CodexParserTest.java
@@ -24,6 +24,7 @@ class CodexParserTest {
         assertThat(receipt.errors()).isEmpty();
 
         assertThat(receipt.items()).containsExactlyElementsOf(expectedItems());
+        assertThat(receipt.generalDiscounts()).containsExactlyElementsOf(expectedGeneralDiscounts());
 
         assertThat(receipt.vats()).containsExactly(
             new LegacyReceiptVat(amount("12.00"), amount("128.60"), amount("1071.46"), amount("1200.06")),
@@ -69,9 +70,12 @@ class CodexParserTest {
             item("Vetekaka 24-p", "7311800009531", "34.95", "1,00 st", "34.95"),
             item("Vispgrädde 40%", "7310867003339", "24.95", "1,00 st", "24.95"),
             item("Wok Thai Style", "7310500187150", "28.95", "1,00 st", "28.95"),
-            item("Yogh Van/blåb 2,5%", "7310867512831", "20.00", "1,00 st", "20.00"),
-            item("Familjerabatt", null, "-66.81", null, "-66.81")
+            item("Yogh Van/blåb 2,5%", "7310867512831", "20.00", "1,00 st", "20.00")
         );
+    }
+
+    private List<LegacyReceiptDiscount> expectedGeneralDiscounts() {
+        return List.of(discount("Familjerabatt", "-66.81"));
     }
 
     private LegacyReceiptItem item(

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
@@ -65,6 +65,9 @@ class LegacyPdfReceiptExtractorTest {
         assertThat(items.get(1)).containsEntry("name", "Äpple");
         assertThat(items.get(1)).containsEntry("unitPrice", new BigDecimal("5.50"));
 
+        List<Map<String, Object>> generalDiscounts = getList(result.structuredData().get("generalDiscounts"));
+        assertThat(generalDiscounts).isEmpty();
+
         List<Map<String, Object>> vats = getList(result.structuredData().get("vats"));
         assertThat(vats).hasSize(1);
         assertThat(vats.get(0)).containsEntry("rate", new BigDecimal("25"));


### PR DESCRIPTION
## Summary
- add a general discount bucket to `LegacyParsedReceipt` and surface it in the structured output
- update the Codex parser to place large standalone discounts such as "Familjerabatt" into the new bucket
- adjust tests and supporting parsers to reflect the additional general discount information

## Testing
- mvn -pl function test

------
https://chatgpt.com/codex/tasks/task_b_68dfcd6b1c388324862cbc433e5150f5