### PR TITLE
Rename NewFormatParser to ReceiptParser and tidy diagnostics

### DIFF
--- a/docs/useful-bash-commands.md
+++ b/docs/useful-bash-commands.md
@@ -1,0 +1,13 @@
+# Useful Bash Commands
+
+```bash
+clear && git pull && ./deploy-cloud-function.sh && gsutil cp ./test-receipt.pdf "gs://$GCS_BUCKET/receipts/large-test-receipt.pdf"
+
+clear && git pull && ./mvnw -pl function -am spring-boot:run \
+    -Dspring-boot.run.profiles=local-receipt-test
+
+clear && curl -F "file=@test-receipt.pdf" http://localhost:8080/local-receipts/parse | jq
+```
+
+These shortcuts assume that `setup-env.sh` has been sourced so that `GCS_BUCKET`
+and other required environment variables are available.

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/DebugConfiguration.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/DebugConfiguration.java
@@ -1,5 +1,7 @@
 package dev.pekelund.responsiveauth.function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
@@ -11,13 +13,17 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class DebugConfiguration {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(DebugConfiguration.class);
+
     @Bean
     public CommandLineRunner debugChatModel(ChatModel chatModel) {
         return args -> {
-            System.out.println("=== Spring AI ChatModel Configuration ===");
-            System.out.println("ChatModel class: " + chatModel.getClass().getName());
-            System.out.println("ChatModel: " + chatModel.toString());
-            System.out.println("=== End Configuration Debug ===");
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("=== Spring AI ChatModel Configuration ===");
+                LOGGER.debug("ChatModel class: {}", chatModel.getClass().getName());
+                LOGGER.debug("ChatModel: {}", chatModel);
+                LOGGER.debug("=== End Configuration Debug ===");
+            }
         };
     }
 }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/PdfParser.java
@@ -23,13 +23,13 @@ public class PdfParser {
         if (pdfData == null || pdfData.length == 0) {
             LOGGER.warn("Attempting to parse empty PDF data");
         } else {
-            LOGGER.info("Parsing PDF data with {} lines", pdfData.length);
+            LOGGER.debug("Parsing PDF data with {} lines", pdfData.length);
             int sampleSize = Math.min(5, pdfData.length);
-            LOGGER.info("PDF data sample: {}", Arrays.toString(Arrays.copyOf(pdfData, sampleSize)));
+            LOGGER.debug("PDF data sample: {}", Arrays.toString(Arrays.copyOf(pdfData, sampleSize)));
         }
 
         ReceiptFormat format = formatDetector.detectFormat(pdfData);
-        LOGGER.info("Detected receipt format: {}", format);
+        LOGGER.debug("Detected receipt format: {}", format);
 
         for (ReceiptFormatParser parser : formatParsers) {
             if (parser.supportsFormat(format)) {

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/ReceiptFormatDetector.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/ReceiptFormatDetector.java
@@ -16,10 +16,10 @@ public class ReceiptFormatDetector {
             return ReceiptFormat.UNKNOWN;
         }
 
-        LOGGER.info("Detecting receipt format for PDF data with {} lines", pdfData.length);
+        LOGGER.debug("Detecting receipt format for PDF data with {} lines", pdfData.length);
 
         int sampleSize = Math.min(5, pdfData.length);
-        LOGGER.info("Receipt header sample: {}", Arrays.toString(Arrays.copyOf(pdfData, sampleSize)));
+        LOGGER.debug("Receipt header sample: {}", Arrays.toString(Arrays.copyOf(pdfData, sampleSize)));
 
         for (String line : pdfData) {
             if (line.contains("Kvittonr:")) {

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/ReceiptParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/ReceiptParser.java
@@ -12,9 +12,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
-class NewFormatParser extends BaseReceiptParser {
+public class ReceiptParser extends BaseReceiptParser {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NewFormatParser.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReceiptParser.class);
 
     private static final Pattern ITEM_PATTERN = Pattern.compile(
         "(?<name>.+?) (?<eanCode>\\d{8,13}) (?<unitPrice>\\d+[.,]\\d{2}) (?<quantity>\\d+(?:[.,]\\d+)?\\s(?:st|kg)) (?<totalPrice>\\d+[.,]\\d{2})");
@@ -76,7 +76,7 @@ class NewFormatParser extends BaseReceiptParser {
 
         List<LegacyReceiptVat> vats = extractVatLines(pdfData, itemsEndIndex + 1);
 
-        LOGGER.info("Parsed NEW_FORMAT receipt - store: {}, date: {}, total: {}, items: {}, vat lines: {}", store,
+        LOGGER.debug("Parsed NEW_FORMAT receipt - store: {}, date: {}, total: {}, items: {}, vat lines: {}", store,
             receiptDate, totalAmount, items.size(), vats.size());
         return new LegacyParsedReceipt(format, store, receiptDate, totalAmount, items, vats, List.of(), errors);
     }

--- a/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/archive/NewFormatParser.java
+++ b/function/src/main/java/dev/pekelund/responsiveauth/function/legacy/archive/NewFormatParser.java
@@ -1,0 +1,23 @@
+package dev.pekelund.responsiveauth.function.legacy.archive;
+
+import dev.pekelund.responsiveauth.function.legacy.ReceiptParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * @deprecated Prefer using {@link dev.pekelund.responsiveauth.function.legacy.ReceiptParser}.
+ * This class is retained to keep compatibility with historical deployments.
+ */
+@Deprecated
+@Component("legacyNewFormatParser")
+@Profile("legacy-new-format")
+public class NewFormatParser extends ReceiptParser {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NewFormatParser.class);
+
+    public NewFormatParser() {
+        LOGGER.warn("Using legacy NewFormatParser bean. Please migrate to ReceiptParser.");
+    }
+}

--- a/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
+++ b/function/src/test/java/dev/pekelund/responsiveauth/function/legacy/LegacyPdfReceiptExtractorTest.java
@@ -29,7 +29,7 @@ class LegacyPdfReceiptExtractorTest {
         objectMapper.findAndRegisterModules();
         ReceiptFormatDetector detector = new ReceiptFormatDetector();
         PdfParser pdfParser = new PdfParser(
-            List.of(new StandardFormatParser(), new NewFormatParser()),
+            List.of(new StandardFormatParser(), new ReceiptParser()),
             detector);
         extractor = new LegacyPdfReceiptExtractor(pdfParser, objectMapper);
     }


### PR DESCRIPTION
## Summary
- rename the legacy NewFormatParser component to ReceiptParser and update callers
- keep a legacy-profile NewFormatParser adapter while reducing noisy logging and debug prints
- document common deployment and testing commands in a new useful bash commands guide

## Testing
- ./mvnw -pl function test

------
https://chatgpt.com/codex/tasks/task_b_68dfd4f5d98883248d811e10e45602f3