### PR TITLE
Add GCP architecture schematics

### DIFF
--- a/docs/cloud-run-deployment.md
+++ b/docs/cloud-run-deployment.md
@@ -1,0 +1,299 @@
+# Deploying the Web Application to Google Cloud Run
+
+This guide walks through provisioning Google Cloud resources, deploying the application to Cloud Run, configuring DNS, and verifying connectivity with Firestore and other Google Cloud services. It contains both **Google Cloud Console** and **gcloud CLI** workflows. Use whichever best fits your workflow, but keep the variables consistent across both approaches.
+
+> 📈 Need a visual reference before diving into the steps? Review the [System Architecture Schematics](./system-architecture-diagrams.md) for high-level diagrams that outline service relationships, data flows, and deployment pipelines.
+
+---
+
+## Prerequisites
+
+1. **Google Cloud project** with billing enabled.
+2. **gcloud CLI** installed locally and authenticated (`gcloud init`).
+3. Access to the Porkbun DNS dashboard for the `pklnd.pekelund.dev` subdomain.
+4. Container image registry access (Artifact Registry or Docker Hub) for storing the built application image.
+5. Source repository cloned locally with access to the application code.
+
+---
+
+## Resource Naming
+
+Replace the placeholders below with your values when following the steps:
+
+| Placeholder | Description |
+|-------------|-------------|
+| `PROJECT_ID` | Google Cloud project ID (e.g., `my-project`). |
+| `REGION` | Supported Cloud Run region (e.g., `europe-north1`). |
+| `SERVICE_NAME` | Desired Cloud Run service name (e.g., `pklnd-web`). |
+| `IMAGE_URI` | Fully qualified container image reference (e.g., `europe-north1-docker.pkg.dev/PROJECT_ID/web/app:latest`). |
+| `DOMAIN` | Fully qualified domain to map (e.g., `pklnd.pekelund.dev`). |
+| `SA_NAME` | Service account name (e.g., `cloud-run-runtime`). |
+| `SHARED_FIRESTORE_PROJECT_ID` | Project that hosts the single Firestore database used by Cloud Run, Cloud Functions, and user registration. Defaults to `PROJECT_ID`. |
+
+---
+
+## 1. Enable Required APIs
+
+### Console
+
+1. Open **Cloud Console** → **APIs & Services** → **Library**.
+2. Enable the following APIs if they are not already enabled:
+   - Cloud Run Admin API
+   - Cloud Build API
+   - Artifact Registry API (or Container Registry if you still use it)
+   - Firestore API
+   - Secret Manager API (if the app reads secrets)
+
+### CLI
+
+```bash
+gcloud services enable \
+  run.googleapis.com \
+  cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com \
+  firestore.googleapis.com \
+  secretmanager.googleapis.com
+```
+
+---
+
+## 2. Configure Firestore and Supporting Infrastructure
+
+### Console
+
+1. Go to **Firestore** → **Create database**.
+2. Select **Native mode** (required for Cloud Run integrations) and choose the same `REGION` that you plan to use for Cloud Run when possible.
+3. Complete the wizard.
+4. If the application relies on Firebase authentication or other services, configure them now.
+
+### CLI
+
+Firestore database creation is a one-time operation. If not already created, run:
+
+```bash
+gcloud firestore databases create --region=REGION --type=firestore-native
+```
+
+> **Note:** If a Firestore database already exists in the project, this command will fail. That is expected—Firestore supports only one database per project.
+
+### Share the database across all components
+
+The same Firestore database stores both the **user registration** data managed by the Cloud Run web application and the **receipt extraction** documents persisted by the Cloud Function. To keep data consistent:
+
+1. Use the same `PROJECT_ID` (or explicitly set `SHARED_FIRESTORE_PROJECT_ID`) for every deployment script and console workflow.
+2. Keep the `users` collection for authentication data and `receiptExtractions` for parsed receipts in the same database.
+3. Reuse the runtime service accounts created in this guide (or grant them `roles/datastore.user`) so the Cloud Run service, Cloud Function, and any local admin scripts can all read/write the shared documents.
+4. When setting environment variables, ensure `FIRESTORE_PROJECT_ID` (Cloud Run) and `RECEIPT_FIRESTORE_PROJECT_ID` (Cloud Function) point to this project. If you override collection names, update both components accordingly.
+
+---
+
+## 3. Create a Runtime Service Account and Grant Permissions
+
+### Console
+
+1. Navigate to **IAM & Admin** → **Service Accounts** → **Create service account**.
+2. Provide `SA_NAME` and description, then click **Create and continue**.
+3. Grant the service account the following roles:
+   - **Cloud Run Service Agent** (`roles/run.serviceAgent`) – automatically added for Cloud Run runtime.
+   - **Cloud Run Invoker** (`roles/run.invoker`) – optional if you plan to make the service public; otherwise, manage access through IAM.
+   - **Datastore User** (`roles/datastore.user`) – required for Firestore access.
+   - **Secret Manager Secret Accessor** (`roles/secretmanager.secretAccessor`) – only if your service uses secrets.
+4. Finish creation and note the service account email (`SA_EMAIL`).
+
+### CLI
+
+```bash
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+gcloud iam service-accounts create "$SA_NAME" \
+  --project "$PROJECT_ID" \
+  --description "Runtime SA for Cloud Run" \
+  --display-name "Cloud Run Runtime"
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role "roles/run.invoker"
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role "roles/datastore.user"
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role "roles/secretmanager.secretAccessor"  # optional
+```
+
+> Cloud Run adds `roles/run.serviceAgent` automatically when the service is deployed. Include additional roles your app needs (Pub/Sub, Storage, etc.).
+
+---
+
+## 4. Build and Push the Container Image
+
+### Console (Cloud Build)
+
+1. Open **Cloud Build** → **Builds** → **Create build**.
+2. Configure a build trigger or run a manual build pointing to the repository.
+3. Ensure the `Dockerfile` is located at the repo root or provide the correct path.
+4. Set the Artifact Registry repository as the build output.
+
+### CLI
+
+From the repository root:
+
+```bash
+PROJECT_ID="..."
+REGION="..."
+SERVICE_NAME="..."
+IMAGE_REPO="${REGION}-docker.pkg.dev/${PROJECT_ID}/web"
+IMAGE_TAG="${IMAGE_REPO}/${SERVICE_NAME}:$(date +%Y%m%d-%H%M%S)"
+
+gcloud artifacts repositories create web \
+  --repository-format=docker \
+  --location="$REGION" \
+  --description="Container images for Cloud Run" 2>/dev/null || true
+
+# Build and push with Cloud Build
+ gcloud builds submit \
+  --tag "$IMAGE_TAG" \
+  --project "$PROJECT_ID"
+```
+
+> Replace the build command if you prefer using `docker build` and `docker push`.
+
+---
+
+## 5. Deploy to Cloud Run
+
+### Console
+
+1. Navigate to **Cloud Run** → **Create service**.
+2. Choose **Deploy one revision from an existing container image**.
+3. Select the `IMAGE_URI` built in the previous step.
+4. Set the service name (`SERVICE_NAME`) and region (`REGION`).
+5. Under **Authentication**, choose whether to allow unauthenticated invocations.
+6. Expand **Security** → **Service account** and select the runtime service account (`SA_EMAIL`).
+7. Set environment variables (Firestore project ID, secrets references, etc.).
+8. Configure CPU/Memory limits and concurrency as required.
+9. Click **Create** to deploy.
+
+### CLI
+
+```bash
+IMAGE_URI="${IMAGE_TAG}"
+ENV_VARS="SPRING_PROFILES_ACTIVE=prod,GOOGLE_CLOUD_PROJECT=${PROJECT_ID},FIRESTORE_PROJECT_ID=${PROJECT_ID}"
+
+ gcloud run deploy "$SERVICE_NAME" \
+  --image "$IMAGE_URI" \
+  --service-account "$SA_EMAIL" \
+  --region "$REGION" \
+  --platform managed \
+  --allow-unauthenticated \
+  --set-env-vars "$ENV_VARS" \
+  --min-instances 0 \
+  --max-instances 10
+```
+
+Adjust min/max instances, authentication, and environment variables as necessary. If access should be restricted, remove `--allow-unauthenticated` and grant IAM access explicitly.
+
+---
+
+## 6. Verify Firestore Connectivity
+
+### Console
+
+1. After deployment, open the Cloud Run service details page.
+2. Check the **Logs** tab for successful Firestore interactions.
+3. Confirm that the application has the correct environment variables (under the **Variables & Secrets** section).
+
+### CLI
+
+```bash
+gcloud run services describe "$SERVICE_NAME" \
+  --region "$REGION" \
+  --format "value(status.url)"
+
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=${SERVICE_NAME}" \
+  --limit 20 \
+  --format json
+```
+
+Ensure the service account has permissions for other Google Cloud products your app uses (Pub/Sub, Storage, etc.).
+
+---
+
+## 7. Map the Custom Domain (pklnd.pekelund.dev)
+
+### Console
+
+1. In Cloud Run, open **Manage custom domains** → **Add mapping**.
+2. Select `pklnd.pekelund.dev` as the domain.
+3. Choose the Cloud Run service and region.
+4. Download the generated DNS records (typically an A or CNAME record pointing to Google-managed endpoints).
+5. In Porkbun:
+   - Log in and edit the DNS records for `pklnd.pekelund.dev`.
+   - Replace the existing record with the values provided by Google (usually a CNAME to `ghs.googlehosted.com` or A records to `199.36.153.4/5/6/7`).
+6. Wait for DNS propagation (can take up to an hour).
+
+### CLI
+
+```bash
+gcloud beta run domain-mappings create \
+  --service "$SERVICE_NAME" \
+  --domain "$DOMAIN" \
+  --region "$REGION"
+```
+
+After running the command, retrieve the DNS records:
+
+```bash
+gcloud beta run domain-mappings describe "$DOMAIN" \
+  --region "$REGION"
+```
+
+Update Porkbun DNS with the returned records. TTL 300 seconds (5 minutes) is sufficient. Use Porkbun's "Records" tab for the subdomain and ensure no conflicting A/CNAME records remain.
+
+---
+
+## 8. Secure the Deployment
+
+1. **HTTPS**: Cloud Run automatically provisions managed certificates once DNS is configured.
+2. **IAM Policies**: Limit who can invoke or manage the service.
+3. **Secrets**: Store sensitive configuration in Secret Manager and mount them as environment variables or volumes.
+4. **VPC Access** (optional): If the application needs to reach private resources, configure a Serverless VPC Access connector.
+5. **Monitoring**: Configure uptime checks, alerts, and dashboards in Cloud Monitoring to track application health.
+
+---
+
+## 9. Deploying Updates
+
+Repeat the build and deploy steps with a new image tag. Cloud Run supports traffic splitting if you need gradual rollouts.
+
+- Build: `gcloud builds submit --tag NEW_IMAGE_URI`
+- Deploy: `gcloud run deploy SERVICE_NAME --image NEW_IMAGE_URI ...`
+
+Rollback by redeploying a previous revision or shifting traffic in the Cloud Run UI.
+
+---
+
+## 10. Cleanup
+
+To remove the Cloud Run service and supporting resources:
+
+```bash
+gcloud run services delete "$SERVICE_NAME" --region "$REGION"
+gcloud artifacts repositories delete web --location "$REGION"
+gcloud firestore databases delete --database="(default)"
+```
+
+Ensure you understand the impact on production data before running cleanup commands.
+
+---
+
+## Troubleshooting Tips
+
+- **Permission denied accessing Firestore**: Verify `roles/datastore.user` is granted to the runtime service account and that the Firestore database exists.
+- **Domain mapping pending**: Check Porkbun DNS records; ensure CNAME/A records match Cloud Run instructions and no conflicting records exist.
+- **Cold starts or latency issues**: Increase min instances or adjust concurrency.
+- **Build failures**: Inspect Cloud Build logs; confirm Dockerfile path and environment variables.
+
+For advanced setups (CI/CD, multiple services, staging environments), extend these instructions with additional automation, Terraform, or Cloud Deploy pipelines.

--- a/docs/gcp-setup-cloud-console.md
+++ b/docs/gcp-setup-cloud-console.md
@@ -34,6 +34,7 @@ Use this guide if you prefer configuring ResponsiveAuthApp resources through the
      export FIRESTORE_PROJECT_ID=your-project-id              # Optional when derived from the key
      export FIRESTORE_USERS_COLLECTION=users                  # Optional override
      export FIRESTORE_DEFAULT_ROLE=ROLE_USER                  # Optional override
+     export RECEIPT_FIRESTORE_PROJECT_ID=$FIRESTORE_PROJECT_ID # Keep Cloud Run + Cloud Function aligned
      ```
 
    - Restart the application to pick up the Firestore integration. Visit `/register` to create your first account and sign in on `/login`.
@@ -98,7 +99,7 @@ Use this guide if you prefer configuring ResponsiveAuthApp resources through the
      - `VERTEX_AI_PROJECT_ID` — defaults to the function project if omitted.
      - `VERTEX_AI_LOCATION` — Vertex AI region that offers Gemini (for example `us-east1` or `us-central1`).
      - `VERTEX_AI_GEMINI_MODEL` — defaults to `gemini-2.0-flash`.
-     - `RECEIPT_FIRESTORE_PROJECT_ID` — optional override when the Firestore database lives in another project.
+     - `RECEIPT_FIRESTORE_PROJECT_ID` — reuse the same project ID exported for the web app to keep all components on one database.
      - `RECEIPT_FIRESTORE_COLLECTION` — defaults to `receiptExtractions`.
    - Upload the source from your local machine or connect the repository, then click **Deploy**.
 

--- a/docs/gcp-setup-gcloud.md
+++ b/docs/gcp-setup-gcloud.md
@@ -63,11 +63,13 @@ gcloud services enable \
 5. **Export the application environment variables**
 
     ```bash
-    export FIRESTORE_ENABLED=true
-    export FIRESTORE_CREDENTIALS=file:/home/$USER/secrets/firestore-service-account.json
-    export FIRESTORE_PROJECT_ID=$(gcloud config get-value project)
-    export FIRESTORE_USERS_COLLECTION=users             # Optional override
-    export FIRESTORE_DEFAULT_ROLE=ROLE_USER             # Optional override
+export FIRESTORE_ENABLED=true
+export FIRESTORE_CREDENTIALS=file:/home/$USER/secrets/firestore-service-account.json
+export FIRESTORE_PROJECT_ID=$(gcloud config get-value project)
+export FIRESTORE_USERS_COLLECTION=users             # Optional override
+export FIRESTORE_DEFAULT_ROLE=ROLE_USER             # Optional override
+# Cloud Run and the Cloud Function reuse this value so every component talks to the same database
+export RECEIPT_FIRESTORE_PROJECT_ID=${FIRESTORE_PROJECT_ID}
     ```
 
 ## Configure Cloud Storage via gcloud
@@ -226,7 +228,7 @@ gcloud services enable cloudfunctions.googleapis.com \
       --set-build-env-vars=MAVEN_BUILD_ARGUMENTS="-pl function -am -DskipTests package" \
       --service-account="${FUNCTION_SA}" \
       --trigger-bucket=$(basename "${BUCKET}") \
-      --set-env-vars=VERTEX_AI_PROJECT_ID=$(gcloud config get-value project),VERTEX_AI_LOCATION=${REGION},VERTEX_AI_GEMINI_MODEL=gemini-2.0-flash,RECEIPT_FIRESTORE_PROJECT_ID=$(gcloud config get-value project),RECEIPT_FIRESTORE_COLLECTION=receiptExtractions
+      --set-env-vars=VERTEX_AI_PROJECT_ID=$(gcloud config get-value project),VERTEX_AI_LOCATION=${REGION},VERTEX_AI_GEMINI_MODEL=gemini-2.0-flash,RECEIPT_FIRESTORE_PROJECT_ID=${RECEIPT_FIRESTORE_PROJECT_ID},RECEIPT_FIRESTORE_COLLECTION=receiptExtractions
     ```
 
 4. **Verify the lifecycle**

--- a/docs/system-architecture-diagrams.md
+++ b/docs/system-architecture-diagrams.md
@@ -1,0 +1,107 @@
+# System Architecture Schematics
+
+The diagrams below illustrate how the responsive auth web application, receipt-processing Cloud Function, and shared Google Cloud resources work together. Replace placeholder values (for example `PROJECT_ID`, `DOMAIN`, or `RECEIPTS_BUCKET`) with your real identifiers when applying the design.
+
+---
+
+## High-Level Service Topology
+
+```mermaid
+flowchart LR
+    subgraph Client[Client]
+        Browser[Web Browser]
+    end
+
+    subgraph DNS[Porkbun DNS Zone]
+        Domain[DOMAIN (CNAME)]
+    end
+
+    subgraph CloudRun[Google Cloud Project \n(PROJECT_ID)]
+        WebApp[Cloud Run Service \nSERVICE_NAME]
+        Secrets[Secret Manager (optional secrets)]
+    end
+
+    subgraph SharedFirestore[Shared Firestore Project \n(SHARED_FIRESTORE_PROJECT_ID)]
+        Firestore[(Firestore \nusers & receiptExtractions collections)]
+    end
+
+    subgraph Storage[Cloud Storage]
+        Bucket[(RECEIPTS_BUCKET)]
+    end
+
+    subgraph Functions[Receipt Processing]
+        GCF[Cloud Function \nreceipt-parser]
+    end
+
+    subgraph VertexAI[Vertex AI \n(PROJECT_ID/REGION)]
+        Gemini[Gemini API]
+    end
+
+    Browser -->|HTTPS request| Domain
+    Domain -->|Custom domain mapping| WebApp
+    WebApp -->|Runtime SA| Firestore
+    WebApp --> Secrets
+    WebApp -->|Signed upload URLs| Bucket
+    Bucket -->|Finalize event| GCF
+    GCF -->|Download object| Bucket
+    GCF -->|Parse receipt| Gemini
+    GCF -->|Write parsed data| Firestore
+    WebApp -->|Query receipts & users| Firestore
+```
+
+**Key points**
+
+- The Cloud Run service and Cloud Function both use identities with the `roles/datastore.user` role against the shared Firestore project so user profiles and receipt documents live in the same database.
+- Custom domain traffic (`DOMAIN`) is routed through Porkbun DNS to the Cloud Run HTTPS endpoint created by the Cloud Run domain mapping workflow.
+- Secrets, OAuth credentials, and API keys should be stored in Secret Manager and referenced through environment variables rather than being hard-coded.
+
+---
+
+## Receipt Processing Sequence
+
+```mermaid
+sequenceDiagram
+    participant User as User
+    participant CloudRun as Cloud Run Web App
+    participant Storage as Cloud Storage Bucket
+    participant GCF as Receipt Cloud Function
+    participant Firestore
+    participant Gemini as Vertex AI Gemini
+
+    User->>CloudRun: Upload receipt (via UI)
+    CloudRun->>Storage: PUT object using signed URL
+    Storage-->>CloudRun: Upload success
+    Storage-->>GCF: Trigger finalize event
+    GCF->>Storage: Download PDF/image
+    GCF->>Gemini: Request structured extraction
+    Gemini-->>GCF: Parsed receipt data
+    GCF->>Firestore: Upsert receiptExtractions document
+    User->>CloudRun: View receipt dashboard
+    CloudRun->>Firestore: Query receiptExtractions & users
+    Firestore-->>CloudRun: Return documents
+    CloudRun-->>User: Render combined view
+```
+
+**Notes**
+
+- The Cloud Function and Cloud Run service share the same Firestore collections. Environment variables such as `FIRESTORE_PROJECT_ID`, `RECEIPT_FIRESTORE_PROJECT_ID`, and `RECEIPT_FIRESTORE_COLLECTION` must point to the shared project and collection names.
+- The signed URL upload pattern prevents the Cloud Run service from proxying large files, while still enforcing authenticated access and storage permissions.
+
+---
+
+## Deployment & Delivery Pipeline
+
+```mermaid
+flowchart LR
+    Developer[Developer Workstation] -->|git push| Repo[Source Repository]
+    Repo -->|Trigger| CloudBuild[Cloud Build]
+    CloudBuild -->|Build container image| ArtifactRegistry[Artifact Registry]
+    ArtifactRegistry -->|Image URI| CloudRunService[Cloud Run Service]
+    CloudRunService -->|Serve HTTPS traffic| EndUsers[Users via DOMAIN]
+```
+
+**Operational checklist**
+
+- The `scripts/deploy_cloud_run.sh` and `deploy-cloud-function.sh` scripts reuse the same environment configuration to keep the Firestore project, service accounts, and regions consistent.
+- Cloud Build can be replaced with local Docker builds if preferred—ensure the final image is pushed to a registry accessible by Cloud Run.
+- After deployment, run the domain mapping workflow so `DOMAIN` resolves to the new Cloud Run service, and verify TLS certificates are provisioned before flipping production traffic.

--- a/scripts/deploy_cloud_run.sh
+++ b/scripts/deploy_cloud_run.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script provisions and deploys the web application to Cloud Run.
+# Configure the environment variables below before running the script.
+
+PROJECT_ID="${PROJECT_ID:-}"
+REGION="${REGION:-europe-north1}"
+SERVICE_NAME="${SERVICE_NAME:-pklnd-web}"
+SA_NAME="${SA_NAME:-cloud-run-runtime}"
+ARTIFACT_REPO="${ARTIFACT_REPO:-web}"
+# Firestore is shared between the Cloud Run app, the Cloud Function and the user registration flow.
+# Default the shared project to the deployment project, but allow overrides when the
+# Firestore database lives in a different project.
+SHARED_FIRESTORE_PROJECT_ID="${SHARED_FIRESTORE_PROJECT_ID:-${PROJECT_ID}}"
+# Append the shared Firestore project ID to the Cloud Run environment variables so the
+# application resolves users from the same database that stores receipt extractions.
+ENV_VARS="${ENV_VARS:-SPRING_PROFILES_ACTIVE=prod}"
+if [[ -n "${SHARED_FIRESTORE_PROJECT_ID}" ]]; then
+  if [[ -z "${ENV_VARS}" ]]; then
+    ENV_VARS="FIRESTORE_PROJECT_ID=${SHARED_FIRESTORE_PROJECT_ID}"
+  elif [[ "${ENV_VARS}" != *"FIRESTORE_PROJECT_ID="* ]]; then
+    ENV_VARS="${ENV_VARS},FIRESTORE_PROJECT_ID=${SHARED_FIRESTORE_PROJECT_ID}"
+  fi
+fi
+ALLOW_UNAUTH="${ALLOW_UNAUTH:-true}"
+DOMAIN="${DOMAIN:-pklnd.pekelund.dev}"
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "PROJECT_ID must be set" >&2
+  exit 1
+fi
+
+set -x
+
+gcloud config set project "$PROJECT_ID"
+
+# Enable core APIs
+ gcloud services enable \
+  run.googleapis.com \
+  cloudbuild.googleapis.com \
+  artifactregistry.googleapis.com \
+  firestore.googleapis.com \
+  secretmanager.googleapis.com
+
+# Create Artifact Registry repository (ignore error if it exists)
+gcloud artifacts repositories create "$ARTIFACT_REPO" \
+  --repository-format=docker \
+  --location="$REGION" \
+  --description="Container images for Cloud Run" || true
+
+# Create Firestore database if missing (ignore error when already provisioned)
+gcloud firestore databases create \
+  --region="$REGION" \
+  --type=firestore-native || true
+
+# Create service account
+SA_EMAIL="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+if ! gcloud iam service-accounts describe "$SA_EMAIL" >/dev/null 2>&1; then
+  gcloud iam service-accounts create "$SA_NAME" \
+    --project "$PROJECT_ID" \
+    --description "Runtime SA for Cloud Run" \
+    --display-name "Cloud Run Runtime"
+fi
+
+# Grant required roles
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role "roles/run.invoker" --condition=None || true
+
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role "roles/datastore.user" --condition=None || true
+
+# Add Secret Manager role only if secrets are required; safe to attempt.
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member "serviceAccount:${SA_EMAIL}" \
+  --role "roles/secretmanager.secretAccessor" --condition=None || true
+
+# Build and push the image
+IMAGE_URI="${REGION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REPO}/${SERVICE_NAME}:$(date +%Y%m%d-%H%M%S)"
+
+gcloud builds submit \
+  --tag "$IMAGE_URI"
+
+# Deploy to Cloud Run
+ALLOW_FLAG="--no-allow-unauthenticated"
+if [[ "$ALLOW_UNAUTH" == "true" ]]; then
+  ALLOW_FLAG="--allow-unauthenticated"
+fi
+
+gcloud run deploy "$SERVICE_NAME" \
+  --image "$IMAGE_URI" \
+  --service-account "$SA_EMAIL" \
+  --region "$REGION" \
+  --platform managed \
+  $ALLOW_FLAG \
+  --set-env-vars "${ENV_VARS}" \
+  --min-instances 0 \
+  --max-instances 10
+
+# Configure custom domain mapping
+gcloud beta run domain-mappings create \
+  --service "$SERVICE_NAME" \
+  --domain "$DOMAIN" \
+  --region "$REGION" || true
+
+gcloud beta run domain-mappings describe "$DOMAIN" \
+  --region "$REGION"
+
+# Display service URL and tail recent logs
+SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" \
+  --region "$REGION" \
+  --format "value(status.url)")
+
+echo "Service deployed: ${SERVICE_URL}"
+
+gcloud logging read "resource.type=cloud_run_revision AND resource.labels.service_name=${SERVICE_NAME}" \
+  --limit 20 \
+  --format="table(timestamp, textPayload)"


### PR DESCRIPTION
## Summary
- add a dedicated system architecture schematics guide with mermaid diagrams that cover service topology, receipt processing, and deployment flow
- link the existing Cloud Run deployment guide to the new visual reference for quick discovery

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68dfdc4fd0a0832491c3e1d3029c817d