### PR TITLE
Add parsed receipts listing and detail view

### DIFF
--- a/core/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptOwnerMatcher.java
+++ b/core/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptOwnerMatcher.java
@@ -1,0 +1,43 @@
+package dev.pekelund.responsiveauth.storage;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Utility methods for comparing {@link ReceiptOwner} instances.
+ */
+public final class ReceiptOwnerMatcher {
+
+    private ReceiptOwnerMatcher() {
+    }
+
+    /**
+     * Determines whether the provided file owner matches the current authenticated owner.
+     *
+     * @param fileOwner    the owner associated with the stored resource
+     * @param currentOwner the owner resolved from the current authentication context
+     * @return {@code true} if the owners represent the same person, otherwise {@code false}
+     */
+    public static boolean belongsToCurrentOwner(ReceiptOwner fileOwner, ReceiptOwner currentOwner) {
+        if (fileOwner == null || currentOwner == null) {
+            return false;
+        }
+
+        if (matches(fileOwner.id(), currentOwner.id())) {
+            return true;
+        }
+
+        if (matchesIgnoreCase(fileOwner.email(), currentOwner.email())) {
+            return true;
+        }
+
+        return matchesIgnoreCase(fileOwner.displayName(), currentOwner.displayName());
+    }
+
+    private static boolean matches(String left, String right) {
+        return StringUtils.hasText(left) && StringUtils.hasText(right) && left.equals(right);
+    }
+
+    private static boolean matchesIgnoreCase(String left, String right) {
+        return StringUtils.hasText(left) && StringUtils.hasText(right) && left.equalsIgnoreCase(right);
+    }
+}

--- a/web/src/main/java/dev/pekelund/responsiveauth/firestore/ParsedReceipt.java
+++ b/web/src/main/java/dev/pekelund/responsiveauth/firestore/ParsedReceipt.java
@@ -2,6 +2,9 @@ package dev.pekelund.responsiveauth.firestore;
 
 import dev.pekelund.responsiveauth.storage.ReceiptOwner;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -25,11 +28,11 @@ public record ParsedReceipt(
 ) {
 
     public ParsedReceipt {
-        general = general != null ? Map.copyOf(general) : Map.of();
-        items = items != null ? List.copyOf(items) : List.of();
-        vats = vats != null ? List.copyOf(vats) : List.of();
-        generalDiscounts = generalDiscounts != null ? List.copyOf(generalDiscounts) : List.of();
-        errors = errors != null ? List.copyOf(errors) : List.of();
+        general = copyOfMap(general);
+        items = copyOfMapList(items);
+        vats = copyOfMapList(vats);
+        generalDiscounts = copyOfMapList(generalDiscounts);
+        errors = copyOfMapList(errors);
     }
 
     public String displayName() {
@@ -79,5 +82,28 @@ public record ParsedReceipt(
     private String valueFromGeneral(String key) {
         Object value = general.get(key);
         return value != null ? value.toString() : null;
+    }
+
+    private static Map<String, Object> copyOfMap(Map<String, Object> source) {
+        if (source == null || source.isEmpty()) {
+            return Map.of();
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+    }
+
+    private static List<Map<String, Object>> copyOfMapList(List<Map<String, Object>> source) {
+        if (source == null || source.isEmpty()) {
+            return List.of();
+        }
+
+        List<Map<String, Object>> copy = new ArrayList<>(source.size());
+        for (Map<String, Object> element : source) {
+            if (element == null || element.isEmpty()) {
+                copy.add(Map.of());
+            } else {
+                copy.add(Collections.unmodifiableMap(new LinkedHashMap<>(element)));
+            }
+        }
+        return Collections.unmodifiableList(copy);
     }
 }

--- a/web/src/main/java/dev/pekelund/responsiveauth/firestore/ParsedReceipt.java
+++ b/web/src/main/java/dev/pekelund/responsiveauth/firestore/ParsedReceipt.java
@@ -1,0 +1,83 @@
+package dev.pekelund.responsiveauth.firestore;
+
+import dev.pekelund.responsiveauth.storage.ReceiptOwner;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+public record ParsedReceipt(
+    String id,
+    String bucket,
+    String objectName,
+    String objectPath,
+    ReceiptOwner owner,
+    String status,
+    String statusMessage,
+    Instant updatedAt,
+    Map<String, Object> general,
+    List<Map<String, Object>> items,
+    List<Map<String, Object>> vats,
+    List<Map<String, Object>> generalDiscounts,
+    List<Map<String, Object>> errors,
+    String rawText,
+    String rawResponse,
+    String error
+) {
+
+    public ParsedReceipt {
+        general = general != null ? Map.copyOf(general) : Map.of();
+        items = items != null ? List.copyOf(items) : List.of();
+        vats = vats != null ? List.copyOf(vats) : List.of();
+        generalDiscounts = generalDiscounts != null ? List.copyOf(generalDiscounts) : List.of();
+        errors = errors != null ? List.copyOf(errors) : List.of();
+    }
+
+    public String displayName() {
+        String fileName = fileName();
+        if (fileName != null && !fileName.isBlank()) {
+            return fileName;
+        }
+        if (objectName != null && !objectName.isBlank()) {
+            return objectName;
+        }
+        return null;
+    }
+
+    public String fileName() {
+        return valueFromGeneral("fileName");
+    }
+
+    public String storeName() {
+        return valueFromGeneral("storeName");
+    }
+
+    public String receiptDate() {
+        return valueFromGeneral("receiptDate");
+    }
+
+    public String totalAmount() {
+        return valueFromGeneral("totalAmount");
+    }
+
+    public String format() {
+        return valueFromGeneral("format");
+    }
+
+    public String statusBadgeClass() {
+        if (status == null || status.isBlank()) {
+            return "bg-secondary-subtle text-secondary";
+        }
+        String normalized = status.trim().toUpperCase();
+        return switch (normalized) {
+            case "COMPLETED" -> "bg-success-subtle text-success";
+            case "FAILED" -> "bg-danger-subtle text-danger";
+            case "PROCESSING", "RUNNING", "PENDING" -> "bg-info-subtle text-info";
+            default -> "bg-secondary-subtle text-secondary";
+        };
+    }
+
+    private String valueFromGeneral(String key) {
+        Object value = general.get(key);
+        return value != null ? value.toString() : null;
+    }
+}

--- a/web/src/main/java/dev/pekelund/responsiveauth/firestore/ReceiptExtractionAccessException.java
+++ b/web/src/main/java/dev/pekelund/responsiveauth/firestore/ReceiptExtractionAccessException.java
@@ -1,0 +1,12 @@
+package dev.pekelund.responsiveauth.firestore;
+
+public class ReceiptExtractionAccessException extends RuntimeException {
+
+    public ReceiptExtractionAccessException(String message) {
+        super(message);
+    }
+
+    public ReceiptExtractionAccessException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/web/src/main/java/dev/pekelund/responsiveauth/firestore/ReceiptExtractionService.java
+++ b/web/src/main/java/dev/pekelund/responsiveauth/firestore/ReceiptExtractionService.java
@@ -1,0 +1,208 @@
+package dev.pekelund.responsiveauth.firestore;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.Timestamp;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.QuerySnapshot;
+import dev.pekelund.responsiveauth.storage.ReceiptOwner;
+import dev.pekelund.responsiveauth.storage.ReceiptOwnerMatcher;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+public class ReceiptExtractionService {
+
+    private static final Logger log = LoggerFactory.getLogger(ReceiptExtractionService.class);
+
+    private final FirestoreProperties properties;
+    private final Optional<Firestore> firestore;
+
+    public ReceiptExtractionService(FirestoreProperties properties, ObjectProvider<Firestore> firestoreProvider) {
+        this.properties = properties;
+        this.firestore = Optional.ofNullable(firestoreProvider.getIfAvailable());
+    }
+
+    public boolean isEnabled() {
+        return firestore.isPresent();
+    }
+
+    public List<ParsedReceipt> listReceiptsForOwner(ReceiptOwner owner) {
+        if (owner == null || firestore.isEmpty()) {
+            return List.of();
+        }
+
+        try {
+            ApiFuture<QuerySnapshot> future = firestore.get()
+                .collection(properties.getReceiptsCollection())
+                .get();
+            QuerySnapshot snapshot = future.get();
+            List<ParsedReceipt> receipts = new ArrayList<>();
+            for (DocumentSnapshot document : snapshot.getDocuments()) {
+                ParsedReceipt parsed = toParsedReceipt(document);
+                if (parsed == null) {
+                    continue;
+                }
+                if (!ReceiptOwnerMatcher.belongsToCurrentOwner(parsed.owner(), owner)) {
+                    continue;
+                }
+                receipts.add(parsed);
+            }
+            receipts.sort(Comparator.comparing(ParsedReceipt::updatedAt,
+                Comparator.nullsLast(Comparator.reverseOrder())));
+            return Collections.unmodifiableList(receipts);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while loading parsed receipts from Firestore", ex);
+            throw new ReceiptExtractionAccessException("Interrupted while loading parsed receipts from Firestore.", ex);
+        } catch (ExecutionException ex) {
+            log.error("Failed to load parsed receipts from Firestore", ex);
+            throw new ReceiptExtractionAccessException("Failed to load parsed receipts from Firestore.", ex);
+        }
+    }
+
+    public Optional<ParsedReceipt> findById(String id) {
+        if (firestore.isEmpty() || !StringUtils.hasText(id)) {
+            return Optional.empty();
+        }
+
+        try {
+            DocumentReference reference = firestore.get()
+                .collection(properties.getReceiptsCollection())
+                .document(id);
+            DocumentSnapshot snapshot = reference.get().get();
+            if (!snapshot.exists()) {
+                return Optional.empty();
+            }
+            return Optional.ofNullable(toParsedReceipt(snapshot));
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while loading parsed receipt {} from Firestore", id, ex);
+            throw new ReceiptExtractionAccessException("Interrupted while loading parsed receipt from Firestore.", ex);
+        } catch (ExecutionException ex) {
+            log.error("Failed to load parsed receipt {} from Firestore", id, ex);
+            throw new ReceiptExtractionAccessException("Failed to load parsed receipt from Firestore.", ex);
+        }
+    }
+
+    private ParsedReceipt toParsedReceipt(DocumentSnapshot snapshot) {
+        Map<String, Object> data = snapshot.getData();
+        if (data == null || data.isEmpty()) {
+            return null;
+        }
+
+        String bucket = asString(data.get("bucket"));
+        String objectName = asString(data.get("objectName"));
+        String objectPath = asString(data.get("objectPath"));
+        String status = asString(data.get("status"));
+        String statusMessage = asString(data.get("statusMessage"));
+        String rawResponse = asString(data.get("rawResponse"));
+        String error = asString(data.get("error"));
+
+        Instant updatedAt = extractUpdatedAt(snapshot, data.get("updatedAt"));
+        ReceiptOwner owner = toReceiptOwner(data.get("owner"));
+
+        Map<String, Object> structuredData = toStringObjectMap(data.get("data"));
+        Map<String, Object> general = toStringObjectMap(structuredData.get("general"));
+        List<Map<String, Object>> items = toMapList(structuredData.get("items"));
+        List<Map<String, Object>> vats = toMapList(structuredData.get("vats"));
+        List<Map<String, Object>> generalDiscounts = toMapList(structuredData.get("generalDiscounts"));
+        List<Map<String, Object>> errors = toMapList(structuredData.get("errors"));
+        String rawText = asString(structuredData.get("rawText"));
+
+        return new ParsedReceipt(
+            snapshot.getId(),
+            bucket,
+            objectName,
+            objectPath,
+            owner,
+            status,
+            statusMessage,
+            updatedAt,
+            general,
+            items,
+            vats,
+            generalDiscounts,
+            errors,
+            rawText,
+            rawResponse,
+            error
+        );
+    }
+
+    private Instant extractUpdatedAt(DocumentSnapshot snapshot, Object fallbackValue) {
+        Timestamp timestamp = snapshot.getTimestamp("updatedAt");
+        if (timestamp == null && fallbackValue instanceof Timestamp fallbackTimestamp) {
+            timestamp = fallbackTimestamp;
+        }
+        if (timestamp == null) {
+            return null;
+        }
+        return timestamp.toDate().toInstant();
+    }
+
+    private ReceiptOwner toReceiptOwner(Object value) {
+        if (!(value instanceof Map<?, ?> map)) {
+            return null;
+        }
+        String id = asString(map.get("id"));
+        String displayName = asString(map.get("displayName"));
+        String email = asString(map.get("email"));
+        ReceiptOwner owner = new ReceiptOwner(id, displayName, email);
+        return owner.hasValues() ? owner : null;
+    }
+
+    private Map<String, Object> toStringObjectMap(Object value) {
+        if (!(value instanceof Map<?, ?> map)) {
+            return Map.of();
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            Object key = entry.getKey();
+            if (key == null) {
+                continue;
+            }
+            result.put(key.toString(), entry.getValue());
+        }
+        return result;
+    }
+
+    private List<Map<String, Object>> toMapList(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Object element : list) {
+            Map<String, Object> mapped = toStringObjectMap(element);
+            if (!mapped.isEmpty()) {
+                result.add(mapped);
+            } else if (element instanceof Map<?, ?> mapElement && mapElement.isEmpty()) {
+                result.add(Map.of());
+            }
+        }
+        return List.copyOf(result);
+    }
+
+    private String asString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof String string) {
+            return StringUtils.hasText(string) ? string : null;
+        }
+        return value.toString();
+    }
+}

--- a/web/src/main/resources/application.yml
+++ b/web/src/main/resources/application.yml
@@ -11,6 +11,7 @@ firestore:
   project-id: ${FIRESTORE_PROJECT_ID:}
   emulator-host: ${FIRESTORE_EMULATOR_HOST:}
   users-collection: ${FIRESTORE_USERS_COLLECTION:users}
+  receipts-collection: ${RECEIPT_FIRESTORE_COLLECTION:receiptExtractions}
   default-role: ${FIRESTORE_DEFAULT_ROLE:ROLE_USER}
 
 gcs:

--- a/web/src/main/resources/templates/receipt-detail.html
+++ b/web/src/main/resources/templates/receipt-detail.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout(${pageTitle}, ~{::section})}">
+<head>
+    <title th:text="${pageTitle}">Receipt details</title>
+</head>
+<body>
+<section class="py-3 py-lg-4">
+    <div class="d-flex align-items-center gap-2 mb-3">
+        <a class="btn btn-link p-0 text-decoration-none" th:href="@{/receipts}">
+            <i class="bi bi-arrow-left"></i>
+            Back to receipts
+        </a>
+    </div>
+
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-start gap-3">
+                <div>
+                    <h1 class="h3 fw-semibold text-primary mb-1"
+                        th:text="${receipt.displayName() != null ? receipt.displayName() : 'Receipt details'}">Receipt details</h1>
+                    <p class="text-muted mb-0" th:if="${receipt.objectPath()}" th:text="${receipt.objectPath()}">gs://bucket/object</p>
+                </div>
+                <span class="badge text-uppercase fw-semibold align-self-start"
+                      th:classappend="' ' + ${receipt.statusBadgeClass()}"
+                      th:text="${receipt.status() != null ? receipt.status() : 'UNKNOWN'}">COMPLETED</span>
+            </div>
+
+            <div class="row mt-4 gy-3">
+                <div class="col-md-6">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Store</dt>
+                        <dd class="col-sm-8" th:text="${receipt.storeName() != null ? receipt.storeName() : '—'}">Store name</dd>
+                        <dt class="col-sm-4">Receipt date</dt>
+                        <dd class="col-sm-8" th:text="${receipt.receiptDate() != null ? receipt.receiptDate() : '—'}">2024-01-01</dd>
+                        <dt class="col-sm-4">Total</dt>
+                        <dd class="col-sm-8" th:text="${receipt.totalAmount() != null ? receipt.totalAmount() : '—'}">129.99</dd>
+                        <dt class="col-sm-4">Format</dt>
+                        <dd class="col-sm-8" th:text="${receipt.format() != null ? receipt.format() : '—'}">NEW_FORMAT</dd>
+                    </dl>
+                </div>
+                <div class="col-md-6">
+                    <dl class="row mb-0">
+                        <dt class="col-sm-4">Updated</dt>
+                        <dd class="col-sm-8"
+                            th:text="${receipt.updatedAt() != null ? #temporals.format(receipt.updatedAt(), 'yyyy-MM-dd HH:mm:ss') : '—'}">
+                            2024-01-01 10:30:00
+                        </dd>
+                        <dt class="col-sm-4">Status message</dt>
+                        <dd class="col-sm-8" th:text="${receipt.statusMessage() != null ? receipt.statusMessage() : '—'}">Completed</dd>
+                        <dt class="col-sm-4">Error</dt>
+                        <dd class="col-sm-8" th:text="${receipt.error() != null ? receipt.error() : '—'}">—</dd>
+                    </dl>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body p-4">
+            <h2 class="h5 fw-semibold mb-3">Items</h2>
+            <div th:if="${#lists.isEmpty(receipt.items())}" class="text-muted">No items were detected.</div>
+            <div th:if="${!#lists.isEmpty(receipt.items())}" class="table-responsive">
+                <table class="table align-middle">
+                    <thead class="table-light">
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col">Quantity</th>
+                        <th scope="col">Unit price</th>
+                        <th scope="col">Total price</th>
+                        <th scope="col">Discounts</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="item : ${receipt.items()}">
+                        <td>
+                            <span class="fw-semibold" th:text="${item['name'] != null ? item['name'] : '—'}">Item name</span>
+                            <div class="text-muted small" th:if="${item['eanCode']}" th:text="'EAN: ' + item['eanCode']">EAN</div>
+                        </td>
+                        <td th:text="${item['quantity'] != null ? item['quantity'] : '—'}">—</td>
+                        <td th:text="${item['unitPrice'] != null ? item['unitPrice'] : '—'}">—</td>
+                        <td th:text="${item['totalPrice'] != null ? item['totalPrice'] : '—'}">—</td>
+                        <td>
+                            <ul class="list-unstyled mb-0"
+                                th:if="${item['discounts'] != null and !#lists.isEmpty(item['discounts'])}">
+                                <li th:each="discount : ${item['discounts']}"
+                                    th:text="${discount['description'] != null ? discount['description'] : 'Discount'} + ' (' + (discount['amount'] != null ? discount['amount'] : '—') + ')'">Discount</li>
+                            </ul>
+                            <span th:if="${item['discounts'] == null or #lists.isEmpty(item['discounts'])}" class="text-muted">—</span>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body p-4">
+            <h2 class="h5 fw-semibold mb-3">VAT summary</h2>
+            <div th:if="${#lists.isEmpty(receipt.vats())}" class="text-muted">No VAT information available.</div>
+            <div th:if="${!#lists.isEmpty(receipt.vats())}" class="table-responsive">
+                <table class="table align-middle">
+                    <thead class="table-light">
+                    <tr>
+                        <th scope="col">Rate</th>
+                        <th scope="col">Net amount</th>
+                        <th scope="col">Tax amount</th>
+                        <th scope="col">Gross amount</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="vat : ${receipt.vats()}">
+                        <td th:text="${vat['rate'] != null ? vat['rate'] : '—'}">—</td>
+                        <td th:text="${vat['netAmount'] != null ? vat['netAmount'] : '—'}">—</td>
+                        <td th:text="${vat['taxAmount'] != null ? vat['taxAmount'] : '—'}">—</td>
+                        <td th:text="${vat['grossAmount'] != null ? vat['grossAmount'] : '—'}">—</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body p-4">
+            <h2 class="h5 fw-semibold mb-3">General discounts</h2>
+            <div th:if="${#lists.isEmpty(receipt.generalDiscounts())}" class="text-muted">No general discounts were found.</div>
+            <ul class="list-group list-group-flush"
+                th:if="${!#lists.isEmpty(receipt.generalDiscounts())}">
+                <li class="list-group-item" th:each="discount : ${receipt.generalDiscounts()}"
+                    th:text="${discount['description'] != null ? discount['description'] : 'Discount'} + ' (' + (discount['amount'] != null ? discount['amount'] : '—') + ')'">
+                    Discount description (amount)
+                </li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body p-4">
+            <h2 class="h5 fw-semibold mb-3">Parsing errors</h2>
+            <div th:if="${#lists.isEmpty(receipt.errors())}" class="text-muted">No parsing errors were reported.</div>
+            <div th:if="${!#lists.isEmpty(receipt.errors())}" class="table-responsive">
+                <table class="table align-middle">
+                    <thead class="table-light">
+                    <tr>
+                        <th scope="col">Line</th>
+                        <th scope="col">Content</th>
+                        <th scope="col">Message</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="error : ${receipt.errors()}">
+                        <td th:text="${error['lineNumber'] != null ? error['lineNumber'] : '—'}">—</td>
+                        <td th:text="${error['content'] != null ? error['content'] : '—'}">—</td>
+                        <td th:text="${error['message'] != null ? error['message'] : '—'}">—</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body p-4">
+            <h2 class="h5 fw-semibold mb-3">Raw receipt text</h2>
+            <pre class="bg-light p-3 rounded small" th:text="${receipt.rawText() != null ? receipt.rawText() : 'No raw text available.'}">No raw text available.</pre>
+
+            <details class="mt-3">
+                <summary class="fw-semibold text-primary">View raw response</summary>
+                <pre class="bg-light p-3 rounded small mt-2"
+                     th:text="${receipt.rawResponse() != null ? receipt.rawResponse() : 'No raw response available.'}">Raw response</pre>
+            </details>
+        </div>
+    </div>
+</section>
+</body>
+</html>

--- a/web/src/main/resources/templates/receipt-detail.html
+++ b/web/src/main/resources/templates/receipt-detail.html
@@ -21,7 +21,7 @@
                     <p class="text-muted mb-0" th:if="${receipt.objectPath()}" th:text="${receipt.objectPath()}">gs://bucket/object</p>
                 </div>
                 <span class="badge text-uppercase fw-semibold align-self-start"
-                      th:classappend="' ' + ${receipt.statusBadgeClass()}"
+                      th:classappend="${receipt.statusBadgeClass()}"
                       th:text="${receipt.status() != null ? receipt.status() : 'UNKNOWN'}">COMPLETED</span>
             </div>
 
@@ -74,7 +74,7 @@
                     <tr th:each="item : ${receipt.items()}">
                         <td>
                             <span class="fw-semibold" th:text="${item['name'] != null ? item['name'] : '—'}">Item name</span>
-                            <div class="text-muted small" th:if="${item['eanCode']}" th:text="'EAN: ' + item['eanCode']">EAN</div>
+                            <div class="text-muted small" th:if="${item['eanCode']}" th:text="${'EAN: ' + item['eanCode']}">EAN</div>
                         </td>
                         <td th:text="${item['quantity'] != null ? item['quantity'] : '—'}">—</td>
                         <td th:text="${item['unitPrice'] != null ? item['unitPrice'] : '—'}">—</td>
@@ -83,7 +83,7 @@
                             <ul class="list-unstyled mb-0"
                                 th:if="${item['discounts'] != null and !#lists.isEmpty(item['discounts'])}">
                                 <li th:each="discount : ${item['discounts']}"
-                                    th:text="${discount['description'] != null ? discount['description'] : 'Discount'} + ' (' + (discount['amount'] != null ? discount['amount'] : '—') + ')'">Discount</li>
+                                    th:text="${(discount['description'] != null ? discount['description'] : 'Discount') + ' (' + (discount['amount'] != null ? discount['amount'] : '—') + ')'}">Discount</li>
                             </ul>
                             <span th:if="${item['discounts'] == null or #lists.isEmpty(item['discounts'])}" class="text-muted">—</span>
                         </td>
@@ -128,7 +128,7 @@
             <ul class="list-group list-group-flush"
                 th:if="${!#lists.isEmpty(receipt.generalDiscounts())}">
                 <li class="list-group-item" th:each="discount : ${receipt.generalDiscounts()}"
-                    th:text="${discount['description'] != null ? discount['description'] : 'Discount'} + ' (' + (discount['amount'] != null ? discount['amount'] : '—') + ')'">
+                    th:text="${(discount['description'] != null ? discount['description'] : 'Discount') + ' (' + (discount['amount'] != null ? discount['amount'] : '—') + ')'}">
                     Discount description (amount)
                 </li>
             </ul>

--- a/web/src/main/resources/templates/receipts.html
+++ b/web/src/main/resources/templates/receipts.html
@@ -120,6 +120,65 @@
         </div>
     </div>
 
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body p-4">
+            <div class="d-flex align-items-center justify-content-between mb-3">
+                <h2 class="h5 fw-semibold mb-0">Parsed receipts</h2>
+                <span class="badge bg-primary-subtle text-primary"
+                      th:if="${parsedReceipts != null and !#lists.isEmpty(parsedReceipts)}"
+                      th:text="${parsedReceipts.size()} + ' receipts'">0 receipts</span>
+            </div>
+
+            <div th:if="${!parsedReceiptsEnabled}" class="alert alert-warning" role="alert">
+                Parsed receipts are currently unavailable. Configure Firestore to enable this feature.
+            </div>
+
+            <div th:if="${parsedListingError}" class="alert alert-danger" role="alert">
+                <span th:text="${parsedListingError}">Unable to load parsed receipts.</span>
+            </div>
+
+            <div th:if="${parsedReceiptsEnabled and (parsedReceipts == null or #lists.isEmpty(parsedReceipts))}" class="text-center text-muted py-5">
+                <p class="mb-0">No receipts have been parsed yet.</p>
+            </div>
+
+            <div th:if="${parsedReceiptsEnabled and parsedReceipts != null and !#lists.isEmpty(parsedReceipts)}" class="table-responsive">
+                <table class="table align-middle">
+                    <thead class="table-light">
+                    <tr>
+                        <th scope="col">Receipt</th>
+                        <th scope="col">Date</th>
+                        <th scope="col">Total</th>
+                        <th scope="col">Status</th>
+                        <th scope="col" class="text-end">Updated</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="parsed : ${parsedReceipts}">
+                        <td>
+                            <a th:href="@{'/receipts/' + ${parsed.id()}}" class="fw-semibold text-decoration-none">
+                                <span th:text="${parsed.displayName() != null ? parsed.displayName() : parsed.objectPath()}">Receipt</span>
+                            </a>
+                            <div class="text-muted small" th:if="${parsed.storeName()}" th:text="${parsed.storeName()}">Store name</div>
+                        </td>
+                        <td th:text="${parsed.receiptDate() != null ? parsed.receiptDate() : '—'}">—</td>
+                        <td th:text="${parsed.totalAmount() != null ? parsed.totalAmount() : '—'}">—</td>
+                        <td>
+                            <span class="badge text-uppercase fw-semibold"
+                                  th:classappend="' ' + ${parsed.statusBadgeClass()}"
+                                  th:text="${parsed.status() != null ? parsed.status() : 'UNKNOWN'}">COMPLETED</span>
+                            <div class="text-muted small" th:if="${parsed.statusMessage()}" th:text="${parsed.statusMessage()}">Status message</div>
+                        </td>
+                        <td class="text-end"
+                            th:text="${parsed.updatedAt() != null ? #temporals.format(parsed.updatedAt(), 'yyyy-MM-dd HH:mm:ss') : '—'}">
+                            2024-01-01 10:30:00
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
     <script defer th:src="@{/js/receipts.js}" th:if="${storageEnabled}"></script>
 </section>
 </body>


### PR DESCRIPTION
## Summary
- add a reusable `ReceiptOwnerMatcher` helper and Firestore-backed `ReceiptExtractionService`
- list parsed receipts on the main receipt page and link to a new detail view
- surface parsed receipt data with new Thymeleaf template and enable collection configuration

## Testing
- ⚠️ `./mvnw -Pinclude-web test` *(aborted because the download-heavy build exceeded the allotted runtime)*

------
https://chatgpt.com/codex/tasks/task_b_68e56cd2560083249f2335bd7915435b