### PR TITLE
Add testing reset button for receipt data

### DIFF
--- a/core/src/main/java/dev/pekelund/responsiveauth/storage/DisabledReceiptStorageService.java
+++ b/core/src/main/java/dev/pekelund/responsiveauth/storage/DisabledReceiptStorageService.java
@@ -26,5 +26,10 @@ public class DisabledReceiptStorageService implements ReceiptStorageService {
     public void uploadFiles(List<MultipartFile> files, ReceiptOwner owner) {
         throw new ReceiptStorageException("Google Cloud Storage integration is disabled");
     }
+
+    @Override
+    public void deleteReceiptsForOwner(ReceiptOwner owner) {
+        throw new ReceiptStorageException("Google Cloud Storage integration is disabled");
+    }
 }
 

--- a/core/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptStorageService.java
+++ b/core/src/main/java/dev/pekelund/responsiveauth/storage/ReceiptStorageService.java
@@ -10,5 +10,7 @@ public interface ReceiptStorageService {
     List<ReceiptFile> listReceipts();
 
     void uploadFiles(List<MultipartFile> files, ReceiptOwner owner);
+
+    void deleteReceiptsForOwner(ReceiptOwner owner);
 }
 

--- a/web/src/main/resources/templates/receipts.html
+++ b/web/src/main/resources/templates/receipts.html
@@ -188,6 +188,24 @@
         </div>
     </div>
 
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body p-4">
+            <h2 class="h5 fw-semibold mb-3">Testing utilities</h2>
+            <p class="text-muted small mb-4">Quickly clear uploaded receipts and parsed receipt data for your
+                account while testing the application.</p>
+            <form th:action="@{/receipts/clear}" method="post" class="d-flex flex-wrap align-items-center gap-3">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                <button type="submit" class="btn btn-outline-danger"
+                        th:disabled="${!storageEnabled and !parsedReceiptsEnabled}">
+                    Clear receipt data
+                </button>
+                <span class="text-muted small" th:if="${!storageEnabled and !parsedReceiptsEnabled}">
+                    Receipt storage and parsing are disabled.
+                </span>
+            </form>
+        </div>
+    </div>
+
     <script defer th:src="@{/js/receipts.js}" th:if="${storageEnabled}"></script>
 </section>
 </body>

--- a/web/src/main/resources/templates/receipts.html
+++ b/web/src/main/resources/templates/receipts.html
@@ -62,17 +62,19 @@
         <div class="col-lg-5">
             <div class="card border-0 shadow-sm h-100">
                 <div class="card-body p-4">
-                    <h2 class="h5 fw-semibold mb-3">Quick start checklist</h2>
-                    <ol class="list-group list-group-numbered list-group-flush">
-                        <li class="list-group-item">Create or select a Google Cloud project.</li>
-                        <li class="list-group-item">Enable the Cloud Storage API and create a bucket for receipts.</li>
-                        <li class="list-group-item">Generate a service account key with Storage Admin access.</li>
-                        <li class="list-group-item">Set the <code>GCS_*</code> environment variables before starting the
-                            app.
-                        </li>
-                    </ol>
-                    <p class="text-muted small mt-3 mb-0">See the repository README for detailed setup instructions and
-                        recommended security practices.</p>
+                    <h2 class="h5 fw-semibold mb-3">Testing utilities</h2>
+                    <p class="text-muted small mb-4">Quickly clear uploaded receipts and parsed receipt data for your
+                        account while testing the application.</p>
+                    <form th:action="@{/receipts/clear}" method="post" class="d-flex flex-wrap align-items-center gap-3">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <button type="submit" class="btn btn-outline-danger"
+                                th:disabled="${!storageEnabled and !parsedReceiptsEnabled}">
+                            Clear receipt data
+                        </button>
+                        <span class="text-muted small" th:if="${!storageEnabled and !parsedReceiptsEnabled}">
+                            Receipt storage and parsing are disabled.
+                        </span>
+                    </form>
                 </div>
             </div>
         </div>
@@ -185,24 +187,6 @@
                     </table>
                 </div>
             </details>
-        </div>
-    </div>
-
-    <div class="card shadow-sm border-0 mt-4">
-        <div class="card-body p-4">
-            <h2 class="h5 fw-semibold mb-3">Testing utilities</h2>
-            <p class="text-muted small mb-4">Quickly clear uploaded receipts and parsed receipt data for your
-                account while testing the application.</p>
-            <form th:action="@{/receipts/clear}" method="post" class="d-flex flex-wrap align-items-center gap-3">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-                <button type="submit" class="btn btn-outline-danger"
-                        th:disabled="${!storageEnabled and !parsedReceiptsEnabled}">
-                    Clear receipt data
-                </button>
-                <span class="text-muted small" th:if="${!storageEnabled and !parsedReceiptsEnabled}">
-                    Receipt storage and parsing are disabled.
-                </span>
-            </form>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- add APIs to delete receipts for the current owner in the storage and Firestore services
- expose a `/receipts/clear` endpoint with a UI button to clear uploaded and parsed receipt data for testing

## Testing
- ./mvnw -Pinclude-web test

------
https://chatgpt.com/codex/tasks/task_b_68e647aad684832496bd81e857b3fe5b