### PR TITLE
Adjust weight display precision to grams

### DIFF
--- a/web/src/main/java/dev/pekelund/responsiveauth/firestore/ParsedReceipt.java
+++ b/web/src/main/java/dev/pekelund/responsiveauth/firestore/ParsedReceipt.java
@@ -222,7 +222,7 @@ public record ParsedReceipt(
             return null;
         }
         BigDecimal normalized = weight.max(BigDecimal.ZERO);
-        BigDecimal scaled = normalized.setScale(2, RoundingMode.HALF_UP);
+        BigDecimal scaled = normalized.setScale(3, RoundingMode.HALF_UP);
         return scaled.toPlainString() + " kg";
     }
 

--- a/web/src/test/java/dev/pekelund/responsiveauth/firestore/ParsedReceiptTest.java
+++ b/web/src/test/java/dev/pekelund/responsiveauth/firestore/ParsedReceiptTest.java
@@ -34,7 +34,7 @@ class ParsedReceiptTest {
         )));
 
         Map<String, Object> item = receipt.displayItems().get(0);
-        assertThat(item.get("displayQuantity")).isEqualTo("0.03 kg");
+        assertThat(item.get("displayQuantity")).isEqualTo("0.026 kg");
         assertThat(item.get("displayUnitPrice")).isEqualTo("590.00");
         assertThat(item.get("displayTotalPrice")).isEqualTo("15.34");
     }
@@ -55,7 +55,7 @@ class ParsedReceiptTest {
     }
 
     @Test
-    void keepsExistingWeightQuantitiesWithTwoDecimals() {
+    void keepsExistingWeightQuantitiesWithThreeDecimals() {
         ParsedReceipt receipt = receiptWithItems(List.of(Map.of(
             "name", "Potatis",
             "unitPrice", new BigDecimal("15.95"),
@@ -64,7 +64,7 @@ class ParsedReceiptTest {
         )));
 
         Map<String, Object> item = receipt.displayItems().get(0);
-        assertThat(item.get("displayQuantity")).isEqualTo("0.75 kg");
+        assertThat(item.get("displayQuantity")).isEqualTo("0.750 kg");
         assertThat(item.get("displayUnitPrice")).isEqualTo("15.95");
         assertThat(item.get("displayTotalPrice")).isEqualTo("11.96");
     }


### PR DESCRIPTION
## Summary
- format displayed weights using three decimal places to represent grams
- update receipt display tests to expect kilogram values with gram precision

## Testing
- ./mvnw -pl web -am -Pinclude-web test

------
https://chatgpt.com/codex/tasks/task_b_68e64f6f7c908324914fcf76624eee13