### PR TITLE
Add live updates to receipts dashboard

### DIFF
--- a/web/src/main/resources/static/css/styles.css
+++ b/web/src/main/resources/static/css/styles.css
@@ -100,7 +100,10 @@ footer {
 }
 
 .details-toggle-icon {
+    width: 1.25rem;
+    height: 1.25rem;
     transition: transform 0.2s ease-in-out;
+    display: inline-block;
 }
 
 details.receipt-table[open] .details-toggle-icon {

--- a/web/src/main/resources/static/img/collapsible-indicator.svg
+++ b/web/src/main/resources/static/img/collapsible-indicator.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+    <circle cx="10" cy="10" r="9" stroke="#0d6efd" stroke-width="1.5" fill="none"/>
+    <path d="M6.5 9.25L10 12.75L13.5 9.25" stroke="#0d6efd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/web/src/main/resources/templates/receipts.html
+++ b/web/src/main/resources/templates/receipts.html
@@ -75,6 +75,7 @@
                             Receipt storage and parsing are disabled.
                         </span>
                     </form>
+                    <div class="w-100 d-none" data-clear-feedback aria-live="polite"></div>
                 </div>
             </div>
         </div>

--- a/web/src/main/resources/templates/receipts.html
+++ b/web/src/main/resources/templates/receipts.html
@@ -4,7 +4,7 @@
     <title th:text="${pageTitle}">Receipts</title>
 </head>
 <body>
-<section class="py-3 py-lg-4">
+<section class="py-3 py-lg-4" th:attr="data-dashboard-url=@{/receipts/dashboard}">
     <div class="row g-4">
         <div class="col-lg-7">
             <div class="card shadow-sm border-0 h-100">
@@ -81,25 +81,29 @@
     </div>
 
     <div class="card shadow-sm border-0 mt-4">
-        <div class="card-body p-4">
-            <details class="receipt-table" open>
-                <summary class="details-toggle d-flex align-items-center justify-content-between mb-3">
-                    <span class="d-flex align-items-center gap-2">
-                        <i class="bi bi-chevron-down details-toggle-icon" aria-hidden="true"></i>
-                        <span class="h5 fw-semibold mb-0">Stored receipts</span>
-                    </span>
-                    <span class="badge bg-primary-subtle text-primary" th:if="${files}" th:text="${files.size()} + ' files'">0 files</span>
-                </summary>
+                <div class="card-body p-4">
+                    <details class="receipt-table" open>
+                        <summary class="details-toggle d-flex align-items-center justify-content-between mb-3">
+                            <span class="d-flex align-items-center gap-2">
+                                <img th:src="@{/img/collapsible-indicator.svg}" src="/img/collapsible-indicator.svg" alt="" class="details-toggle-icon" aria-hidden="true">
+                                <span class="h5 fw-semibold mb-0">Stored receipts</span>
+                            </span>
+                            <span class="badge bg-primary-subtle text-primary" data-files-count
+                                  th:classappend="${files == null or #lists.isEmpty(files)} ? ' d-none'"
+                                  th:text="${files != null ? files.size() + ' files' : '0 files'}">0 files</span>
+                        </summary>
 
                 <div th:if="${listingError}" class="alert alert-danger" role="alert">
                     <span th:text="${listingError}">Unable to list files.</span>
                 </div>
 
-                <div th:if="${files == null or #lists.isEmpty(files)}" class="text-center text-muted py-5">
+                <div class="text-center text-muted py-5" data-files-empty
+                     th:classappend="${files != null and !#lists.isEmpty(files)} ? ' d-none'">
                     <p class="mb-0">No receipts have been uploaded yet.</p>
                 </div>
 
-                <div th:if="${files != null and !#lists.isEmpty(files)}" class="table-responsive">
+                <div class="table-responsive" data-files-table
+                     th:classappend="${files == null or #lists.isEmpty(files)} ? ' d-none'">
                     <table class="table align-middle">
                         <thead class="table-light">
                         <tr>
@@ -107,17 +111,28 @@
                             <th scope="col" class="text-end">Size</th>
                             <th scope="col">Uploaded by</th>
                             <th scope="col">Last updated</th>
+                            <th scope="col">Status</th>
                             <th scope="col">Content type</th>
                         </tr>
                         </thead>
-                        <tbody>
-                        <tr th:each="file : ${files}">
+                        <tbody data-files-body>
+                        <tr th:each="file : ${files}" th:attr="data-object-name=${file.name()}">
                             <td>
                                 <span class="fw-semibold" th:text="${file.name()}">receipt.pdf</span>
                             </td>
                             <td class="text-end" th:text="${file.formattedSize()}">24.5 KB</td>
                             <td th:text="${file.ownerDisplayName()}">—</td>
                             <td th:text="${file.updated() != null ? #temporals.format(file.updated(), 'yyyy-MM-dd HH:mm:ss') : '—'}">2024-01-01 10:30:00</td>
+                            <td th:with="status=${fileStatuses != null ? fileStatuses[file.name()] : null}">
+                                <div class="d-flex flex-column gap-1">
+                                    <span class="badge text-uppercase fw-semibold file-status-badge"
+                                          th:classappend="${status != null ? ' ' + status.statusBadgeClass() : ' bg-secondary-subtle text-secondary'}"
+                                          th:text="${status != null && status.status() != null ? status.status() : 'PENDING'}">PENDING</span>
+                                    <span class="text-muted small file-status-message"
+                                          th:classappend="${status == null || status.statusMessage() == null} ? ' d-none'"
+                                          th:text="${status != null ? status.statusMessage() : ''}">Status message</span>
+                                </div>
+                            </td>
                             <td th:text="${file.contentType() != null ? file.contentType() : '—'}">application/pdf</td>
                         </tr>
                         </tbody>
@@ -132,12 +147,12 @@
             <details class="receipt-table" open>
                 <summary class="details-toggle d-flex align-items-center justify-content-between mb-3">
                     <span class="d-flex align-items-center gap-2">
-                        <i class="bi bi-chevron-down details-toggle-icon" aria-hidden="true"></i>
+                        <img th:src="@{/img/collapsible-indicator.svg}" src="/img/collapsible-indicator.svg" alt="" class="details-toggle-icon" aria-hidden="true">
                         <span class="h5 fw-semibold mb-0">Parsed receipts</span>
                     </span>
-                    <span class="badge bg-primary-subtle text-primary"
-                          th:if="${parsedReceipts != null and !#lists.isEmpty(parsedReceipts)}"
-                          th:text="${parsedReceipts.size()} + ' receipts'">0 receipts</span>
+                    <span class="badge bg-primary-subtle text-primary" data-parsed-count
+                          th:classappend="${parsedReceipts == null or #lists.isEmpty(parsedReceipts)} ? ' d-none'"
+                          th:text="${parsedReceipts != null ? parsedReceipts.size() + ' receipts' : '0 receipts'}">0 receipts</span>
                 </summary>
 
                 <div th:if="${!parsedReceiptsEnabled}" class="alert alert-warning" role="alert">
@@ -148,11 +163,13 @@
                     <span th:text="${parsedListingError}">Unable to load parsed receipts.</span>
                 </div>
 
-                <div th:if="${parsedReceiptsEnabled and (parsedReceipts == null or #lists.isEmpty(parsedReceipts))}" class="text-center text-muted py-5">
+                <div class="text-center text-muted py-5" data-parsed-empty
+                     th:classappend="${!parsedReceiptsEnabled or (parsedReceipts != null and !#lists.isEmpty(parsedReceipts))} ? ' d-none' : ''">
                     <p class="mb-0">No receipts have been parsed yet.</p>
                 </div>
 
-                <div th:if="${parsedReceiptsEnabled and parsedReceipts != null and !#lists.isEmpty(parsedReceipts)}" class="table-responsive">
+                <div class="table-responsive" data-parsed-table
+                     th:classappend="${!parsedReceiptsEnabled or parsedReceipts == null or #lists.isEmpty(parsedReceipts)} ? ' d-none'">
                     <table class="table align-middle">
                         <thead class="table-light">
                         <tr>
@@ -162,22 +179,16 @@
                             <th scope="col" class="text-end">Updated</th>
                         </tr>
                         </thead>
-                        <tbody>
-                        <tr th:each="parsed : ${parsedReceipts}">
+                        <tbody data-parsed-body>
+                        <tr th:each="parsed : ${parsedReceipts}" th:attr="data-receipt-id=${parsed.id()}">
                             <td>
                                 <a th:href="@{'/receipts/' + ${parsed.id()}}" class="fw-semibold text-decoration-none">
                                     <span th:text="${parsed.displayName() != null ? parsed.displayName() : parsed.objectPath()}">Receipt</span>
                                 </a>
                                 <div class="text-muted small" th:if="${parsed.storeName()}" th:text="${parsed.storeName()}">Store name</div>
-                                <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
-                                    <span class="badge text-uppercase fw-semibold"
-                                          th:classappend="' ' + ${parsed.statusBadgeClass()}"
-                                          th:text="${parsed.status() != null ? parsed.status() : 'UNKNOWN'}">COMPLETED</span>
-                                    <span class="text-muted small" th:if="${parsed.statusMessage()}" th:text="${parsed.statusMessage()}">Status message</span>
-                                </div>
                             </td>
                             <td th:text="${parsed.receiptDate() != null ? parsed.receiptDate() : '—'}">—</td>
-                            <td th:text="${parsed.totalAmount() != null ? parsed.totalAmount() : '—'}">—</td>
+                            <td th:text="${parsed.formattedTotalAmount() != null ? parsed.formattedTotalAmount() : (parsed.totalAmount() != null ? parsed.totalAmount() : '—')}">—</td>
                             <td class="text-end"
                                 th:text="${parsed.updatedAt() != null ? #temporals.format(parsed.updatedAt(), 'yyyy-MM-dd HH:mm:ss') : '—'}">
                                 2024-01-01 10:30:00
@@ -190,7 +201,7 @@
         </div>
     </div>
 
-    <script defer th:src="@{/js/receipts.js}" th:if="${storageEnabled}"></script>
+    <script defer th:src="@{/js/receipts.js}"></script>
 </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an API-backed dashboard response so the receipts page can expose file status details and keep existing lists filtered for the current owner
- refresh the receipts template, styles, and assets to surface a folding indicator image and a status column on stored files
- add polling logic that rebuilds the file and parsed receipt tables so changes appear automatically without reloading the page

## Testing
- ./mvnw -pl web -am -Pinclude-web test

------
https://chatgpt.com/codex/tasks/task_b_68e651b6350083249c00d678ca80182f